### PR TITLE
move remaining core-provider code to clients

### DIFF
--- a/packages/clients/src/index.ts
+++ b/packages/clients/src/index.ts
@@ -3,3 +3,6 @@ export * from "./createClients.js";
 export * from "./createPaymasterClient.js";
 export * from "./createPublicClient.js";
 export * from "./createUserManagedAccount.js";
+
+// TODO: legacy code from core-provider, need to refactor
+export * from "./legacy/index.js";

--- a/packages/clients/src/legacy/index.ts
+++ b/packages/clients/src/legacy/index.ts
@@ -1,0 +1,5 @@
+export * from "./localAccounts.js";
+export * from "./rpcUrls.js";
+export * from "./simpleSmartAccountClients.js";
+export * from "./simpleSmartAccounts.js";
+export * from "./transports.js";

--- a/packages/clients/src/legacy/localAccounts.ts
+++ b/packages/clients/src/legacy/localAccounts.ts
@@ -1,0 +1,125 @@
+import { Address, LocalAccount, SignableMessage, createClient } from "viem";
+import { getAddresses, signMessage } from "viem/actions";
+import { toAccount } from "viem/accounts";
+import { API_REST_BASE_URL } from "@owlprotocol/envvars";
+import { Auth, getOwlAdminSignTransport, getOwlUserSignTransport } from "./transports.js";
+
+export interface CreateUserLocalAccountParameters {
+    jwt: string;
+    projectId: string;
+    address?: Address;
+}
+
+export interface CreateAdminLocalAccountParameters {
+    auth: Auth;
+    projectId: string;
+    address?: Address;
+}
+
+export async function createUserLocalAccount(
+    parameters: CreateUserLocalAccountParameters,
+    owlRestApiUrl = API_REST_BASE_URL,
+): Promise<LocalAccount> {
+    const { jwt, projectId } = parameters;
+    let { address } = parameters;
+
+    const transport = getOwlUserSignTransport(jwt, projectId, owlRestApiUrl);
+
+    const client = createClient({ transport }).extend((client) => ({
+        getAddresses: () => getAddresses(client),
+    }));
+
+    if (!address) {
+        [address] = await client.getAddresses();
+
+        if (!address) {
+            throw new Error("No address for this user");
+        }
+    }
+
+    const account = address!;
+
+    // Now that we have an account, extend with sign message too
+    const clientWithAccount = client.extend((client) => ({
+        signMessage: ({ message }: { message: SignableMessage }) => signMessage(client, { message, account }),
+    }));
+
+    return toAccount({
+        address,
+        signMessage: clientWithAccount.signMessage,
+        // TODO: Implement
+        // async signTransaction(transaction, args) {
+        async signTransaction() {
+            throw new Error("Unimplemented");
+        },
+        // TODO: Implement
+        // async signTypedData(typedData) {
+        async signTypedData() {
+            // if (!typedData.types || !typedData.message || !typedData.primaryType) {
+            //     throw new Error("Typed data types must be defined");
+            // }
+            // return walletClient.signTypedData({
+            //     account,
+            //     message: typedData.message,
+            //     primaryType: typedData.primaryType,
+            //     types: typedData.types,
+            //     domain: typedData.domain,
+            // });
+            throw new Error("Unimplemented");
+        },
+    });
+}
+
+export async function createAdminLocalAccount(
+    parameters: CreateAdminLocalAccountParameters,
+    owlRestApiUrl = API_REST_BASE_URL,
+): Promise<LocalAccount> {
+    const { auth, projectId } = parameters;
+    let { address } = parameters;
+
+    const transport = getOwlAdminSignTransport(auth, projectId, owlRestApiUrl);
+
+    const client = createClient({ transport }).extend((client) => ({
+        getAddresses: () => getAddresses(client),
+    }));
+
+    if (!address) {
+        [address] = await client.getAddresses();
+
+        if (!address) {
+            throw new Error("No address for this user");
+        }
+    }
+
+    const account = address!;
+
+    // Now that we have an account, extend with sign message too
+    const clientWithAccount = client.extend((client) => ({
+        signMessage: ({ message }: { message: SignableMessage }) => signMessage(client, { message, account }),
+    }));
+
+    return toAccount({
+        address,
+        signMessage: clientWithAccount.signMessage,
+        // TODO: Implement
+        // async signTransaction(transaction, args) {
+        async signTransaction() {
+            throw new Error("Unimplemented");
+        },
+        // TODO: Implement
+        // async signTypedData(typedData) {
+        async signTypedData() {
+            // if (!typedData.types || !typedData.message || !typedData.primaryType) {
+            //     throw new Error("Typed data types must be defined");
+            // }
+            // return walletClient.signTypedData({
+            //     account,
+            //     message: typedData.message,
+            //     primaryType: typedData.primaryType,
+            //     types: typedData.types,
+            //     domain: typedData.domain,
+            // });
+            throw new Error("Unimplemented");
+        },
+    });
+}

--- a/packages/clients/src/legacy/rpcUrls.ts
+++ b/packages/clients/src/legacy/rpcUrls.ts
@@ -1,0 +1,16 @@
+import { API_REST_BASE_URL } from "@owlprotocol/envvars";
+
+export const getOwlRpcUrl = (chainId: number, owlApiRestBaseUrl = API_REST_BASE_URL) =>
+    `${owlApiRestBaseUrl}/network/${chainId}/rpc`;
+
+export const getOwlUserRpcUrl = (projectId: string, chainId: number, owlApiRestBaseUrl = API_REST_BASE_URL) =>
+    `${owlApiRestBaseUrl}/project/${projectId}/network/${chainId}/userRpc`;
+
+export const getOwlUserSignUrl = (projectId: string, owlApiRestBaseUrl = API_REST_BASE_URL) =>
+    `${owlApiRestBaseUrl}/project/${projectId}/userSignRpc`;
+
+export const getOwlAdminRpcUrl = (projectId: string, chainId: number, owlApiRestBaseUrl = API_REST_BASE_URL) =>
+    `${owlApiRestBaseUrl}/project/${projectId}/network/${chainId}/adminRpc`;
+
+export const getOwlAdminSignUrl = (projectId: string, owlApiRestBaseUrl = API_REST_BASE_URL) =>
+    `${owlApiRestBaseUrl}/project/${projectId}/adminSignRpc`;

--- a/packages/clients/src/legacy/simpleSmartAccountClients.ts
+++ b/packages/clients/src/legacy/simpleSmartAccountClients.ts
@@ -1,0 +1,74 @@
+import { type SmartAccountClient, createSmartAccountClient } from "permissionless";
+import { type Chain, type HttpTransport, type Address } from "viem";
+import { createPimlicoPaymasterClient } from "permissionless/clients/pimlico";
+import { ENTRYPOINT_ADDRESS_V07_TYPE } from "permissionless/types";
+import { ENTRYPOINT_ADDRESS_V07 } from "permissionless/utils";
+import { API_REST_BASE_URL } from "@owlprotocol/envvars";
+import { getAdminSimpleSmartAccount, getUserSimpleSmartAccount } from "./simpleSmartAccounts.js";
+import { getOwlUserRpcTransport, Auth, getOwlAdminRpcTransport } from "./transports.js";
+
+export async function getUserSimpleSmartAccountClient(
+    jwt: string,
+    projectId: string,
+    chain: Chain,
+    owlApiRestBaseUrl = API_REST_BASE_URL,
+    factoryAddress: Address = "0xe7A78BA9be87103C317a66EF78e6085BD74Dd538",
+): Promise<SmartAccountClient<ENTRYPOINT_ADDRESS_V07_TYPE, HttpTransport, typeof chain>> {
+    const simpleSmartAccount = await getUserSimpleSmartAccount(
+        jwt,
+        projectId,
+        chain,
+        owlApiRestBaseUrl,
+        factoryAddress,
+    );
+
+    const owlRpcTransport = getOwlUserRpcTransport(jwt, projectId, chain.id, owlApiRestBaseUrl);
+
+    const paymasterClient = createPimlicoPaymasterClient({
+        transport: owlRpcTransport,
+        entryPoint: ENTRYPOINT_ADDRESS_V07,
+    });
+
+    return createSmartAccountClient({
+        account: simpleSmartAccount,
+        entryPoint: ENTRYPOINT_ADDRESS_V07,
+        chain,
+        bundlerTransport: owlRpcTransport,
+        middleware: {
+            sponsorUserOperation: paymasterClient.sponsorUserOperation,
+        },
+    });
+}
+
+export async function getAdminSimpleSmartAccountClient(
+    auth: Auth,
+    projectId: string,
+    chain: Chain,
+    owlApiRestBaseUrl = API_REST_BASE_URL,
+    factoryAddress: Address = "0xe7A78BA9be87103C317a66EF78e6085BD74Dd538",
+): Promise<SmartAccountClient<ENTRYPOINT_ADDRESS_V07_TYPE, HttpTransport, typeof chain>> {
+    const simpleSmartAccount = await getAdminSimpleSmartAccount(
+        auth,
+        projectId,
+        chain,
+        owlApiRestBaseUrl,
+        factoryAddress,
+    );
+
+    const owlRpcTransport = getOwlAdminRpcTransport(auth, projectId, chain.id, owlApiRestBaseUrl);
+
+    const paymasterClient = createPimlicoPaymasterClient({
+        transport: owlRpcTransport,
+        entryPoint: ENTRYPOINT_ADDRESS_V07,
+    });
+
+    return createSmartAccountClient({
+        account: simpleSmartAccount,
+        entryPoint: ENTRYPOINT_ADDRESS_V07,
+        chain,
+        bundlerTransport: owlRpcTransport,
+        middleware: {
+            sponsorUserOperation: paymasterClient.sponsorUserOperation,
+        },
+    });
+}

--- a/packages/clients/src/legacy/simpleSmartAccounts.ts
+++ b/packages/clients/src/legacy/simpleSmartAccounts.ts
@@ -1,0 +1,54 @@
+import { type Address, type Chain, createPublicClient } from "viem";
+import { signerToSimpleSmartAccount } from "permissionless/accounts";
+import { ENTRYPOINT_ADDRESS_V07 } from "permissionless/utils";
+import { API_REST_BASE_URL } from "@owlprotocol/envvars";
+import { type Auth, getOwlRpcTransport, getOwlUserRpcTransport } from "./transports.js";
+import { createAdminLocalAccount, createUserLocalAccount } from "./localAccounts.js";
+
+export async function getUserSimpleSmartAccount(
+    jwt: string,
+    projectId: string,
+    chain: Chain,
+    owlApiRestBaseUrl = API_REST_BASE_URL,
+    factoryAddress: Address = "0xe7A78BA9be87103C317a66EF78e6085BD74Dd538",
+) {
+    const publicClient = createPublicClient({
+        chain,
+        transport: getOwlUserRpcTransport(jwt, projectId, chain.id, owlApiRestBaseUrl),
+    });
+
+    const localClient = await createUserLocalAccount({ jwt, projectId }, owlApiRestBaseUrl);
+
+    return signerToSimpleSmartAccount(publicClient, {
+        signer: localClient,
+        entryPoint: ENTRYPOINT_ADDRESS_V07,
+        factoryAddress,
+    });
+}
+
+export async function getAdminSimpleSmartAccount(
+    auth: Auth,
+    projectId: string,
+    chain: Chain,
+    owlApiRestBaseUrl = API_REST_BASE_URL,
+    factoryAddress: Address = "0xe7A78BA9be87103C317a66EF78e6085BD74Dd538",
+) {
+    const publicClient = createPublicClient({
+        chain,
+        transport: getOwlRpcTransport(chain.id, owlApiRestBaseUrl),
+    });
+
+    const localClient = await createAdminLocalAccount(
+        {
+            auth,
+            projectId,
+        },
+        owlApiRestBaseUrl,
+    );
+
+    return signerToSimpleSmartAccount(publicClient, {
+        signer: localClient,
+        entryPoint: ENTRYPOINT_ADDRESS_V07,
+        factoryAddress,
+    });
+}

--- a/packages/clients/src/legacy/transports.ts
+++ b/packages/clients/src/legacy/transports.ts
@@ -1,0 +1,49 @@
+import { http } from "viem";
+import { API_REST_BASE_URL } from "@owlprotocol/envvars";
+import { getOwlAdminRpcUrl, getOwlAdminSignUrl, getOwlRpcUrl, getOwlUserRpcUrl, getOwlUserSignUrl } from "./rpcUrls.js";
+
+export type Auth = { jwt: string; apiKey?: never } | { apiKey: string; jwt?: never };
+
+export const getJwtAuthHeaders = (jwt: string) => ({ authorization: `Bearer ${jwt}` });
+
+export const getAuthHeaders = (auth: Auth) => {
+    if (auth.apiKey) {
+        return { "x-api-key": auth.apiKey };
+    }
+
+    // From type definition, jwt has to be defined
+    return getJwtAuthHeaders(auth.jwt!);
+};
+
+export const getOwlRpcTransport = (chainId: number, owlApiRestBaseUrl = API_REST_BASE_URL) =>
+    http(getOwlRpcUrl(chainId, owlApiRestBaseUrl));
+
+export const getOwlUserRpcTransport = (
+    jwt: string,
+    projectId: string,
+    chainId: number,
+    owlApiRestBaseUrl = API_REST_BASE_URL,
+) =>
+    http(getOwlUserRpcUrl(projectId, chainId, owlApiRestBaseUrl), {
+        fetchOptions: { headers: getJwtAuthHeaders(jwt) },
+    });
+
+export const getOwlUserSignTransport = (jwt: string, projectId: string, owlApiRestBaseUrl = API_REST_BASE_URL) =>
+    http(getOwlUserSignUrl(projectId, owlApiRestBaseUrl), {
+        fetchOptions: { headers: getJwtAuthHeaders(jwt) },
+    });
+
+export const getOwlAdminRpcTransport = (
+    auth: Auth,
+    projectId: string,
+    chainId: number,
+    owlApiRestBaseUrl = API_REST_BASE_URL,
+) =>
+    http(getOwlAdminRpcUrl(projectId, chainId, owlApiRestBaseUrl), {
+        fetchOptions: { headers: getAuthHeaders(auth) },
+    });
+
+export const getOwlAdminSignTransport = (auth: Auth, projectId: string, owlApiRestBaseUrl = API_REST_BASE_URL) =>
+    http(getOwlAdminSignUrl(projectId, owlApiRestBaseUrl), {
+        fetchOptions: { headers: getAuthHeaders(auth) },
+    });


### PR DESCRIPTION
Code in `@owlprotocol/clients` from `@owlprotocol/core-provider` marked as legacy for future refactor to align better with viem interfaces