### PR TITLE
refactor: deployer utils

### DIFF
--- a/packages/backend-bundler/src/eip1193/createBundlerEIP1193.test.ts
+++ b/packages/backend-bundler/src/eip1193/createBundlerEIP1193.test.ts
@@ -80,10 +80,7 @@ describe("eip1993/creatBundlerEIP1193.test.ts", function () {
         });
 
         // ERC4337 Contracts
-        const contracts = await setupERC4337Contracts({
-            publicClient,
-            walletClient,
-        });
+        const contracts = await setupERC4337Contracts(walletClient);
         entryPointAddress = contracts.entrypoint.address;
         entryPointSimulationsAddress = contracts.pimlicoEntrypointSimulations.address;
         factoryAddress = contracts.simpleAccountFactory.address;
@@ -183,7 +180,7 @@ describe("eip1993/creatBundlerEIP1193.test.ts", function () {
             const receipt = await publicClient.waitForTransactionReceipt({ hash });
             expect(receipt).toBeDefined();
 
-            const contractBytecode = await publicClient.getBytecode({ address: contractAddressExpected });
+            const contractBytecode = await publicClient.getCode({ address: contractAddressExpected });
             expect(contractBytecode).toBeDefined();
 
             // Check Firebase indexing
@@ -203,7 +200,7 @@ describe("eip1993/creatBundlerEIP1193.test.ts", function () {
             const userOpReceipt = await waitForUserOperationReceipt(bundlerClient, { hash: userOpHash });
             expect(userOpReceipt).toBeDefined();
 
-            const contractBytecode = await publicClient.getBytecode({ address: contractAddressExpected });
+            const contractBytecode = await publicClient.getCode({ address: contractAddressExpected });
             expect(contractBytecode).toBeDefined();
 
             // Check Firebase indexing

--- a/packages/chains-deploy/src/scripts/deployNetwork.ts
+++ b/packages/chains-deploy/src/scripts/deployNetwork.ts
@@ -2,7 +2,7 @@ import { kaiaTestnet } from "@owlprotocol/chains";
 import { networkPrivateResource } from "@owlprotocol/core-firebase/admin";
 
 import { getUtilityAccount, getRelayerAccount, getPaymasterSignerAccount } from "@owlprotocol/viem-utils";
-import { Chain, createPublicClient, createWalletClient, http } from "viem";
+import { Chain, createWalletClient, http } from "viem";
 import { setupChain } from "../setupChain.js";
 
 export async function main() {
@@ -18,10 +18,6 @@ export async function main() {
     const network = kaiaTestnet;
 
     const chain = { id: network.chainId, ...network } as Chain;
-    const publicClient = createPublicClient({
-        transport: http(chain.rpcUrls.default.http[0]),
-        chain,
-    });
     const walletClient = createWalletClient({
         transport: http(chain.rpcUrls.default.http[0]),
         chain,
@@ -30,12 +26,6 @@ export async function main() {
     // L1 (opstack)
     const networkL1 = chain.sourceId ? await networkPrivateResource.getOrNull({ chainId: chain.sourceId }) : null;
     const chainL1 = networkL1 ? ({ id: networkL1.chainId, ...networkL1 } as Chain) : undefined;
-    const publicClientL1 = chainL1
-        ? createPublicClient({
-              transport: http(chainL1.rpcUrls.default.http[0]),
-              chain: chainL1,
-          })
-        : undefined;
     const walletClientL1 = chainL1
         ? createWalletClient({
               transport: http(chainL1.rpcUrls.default.http[0]),
@@ -46,13 +36,10 @@ export async function main() {
 
     console.debug(`🛠️  Deploying ${network.name}`);
 
-    const result = await setupChain({
-        publicClient,
-        walletClient,
+    const result = await setupChain(walletClient, {
         bundlerAddress: bundlerAccount.address,
         verifyingSignerAddress: paymasterSignerAccount.address,
-        publicClientL1: publicClientL1 as any,
-        walletClientL1: walletClientL1 as any,
+        clientL1: walletClientL1 as any,
         bundlerTargetBalance: network.targetRelayerBalance as bigint,
         bundlerMinBalance: network.minRelayerBalance as bigint,
         paymasterTargetBalance: network.targetPaymasterBalance as bigint,

--- a/packages/chains-deploy/src/setupNetworks.ts
+++ b/packages/chains-deploy/src/setupNetworks.ts
@@ -4,7 +4,7 @@ import { Network, NetworkDataInput, networkPrivateResource, networkResource } fr
 import { localhost, opBedrockL1, opBedrockL2 } from "@owlprotocol/chains";
 import * as chains from "@owlprotocol/chains/chains";
 import { getUtilityAccount, getRelayerAccount, getPaymasterSignerAccount } from "@owlprotocol/viem-utils";
-import { Chain, createPublicClient, createWalletClient, http } from "viem";
+import { Chain, createWalletClient, http } from "viem";
 import { setupChain } from "./setupChain.js";
 
 /**
@@ -108,10 +108,6 @@ export async function setupNetworksForEnv() {
     const { networksPrivate } = await uploadNetworks(data);
     for (const network of networksPrivate) {
         const chain = { id: network.chainId, ...network } as Chain;
-        const publicClient = createPublicClient({
-            transport: http(chain.rpcUrls.default.http[0]),
-            chain,
-        });
         const walletClient = createWalletClient({
             transport: http(chain.rpcUrls.default.http[0]),
             chain,
@@ -120,12 +116,6 @@ export async function setupNetworksForEnv() {
         // L1 (opstack)
         const networkL1 = chain.sourceId ? await networkPrivateResource.getOrNull({ chainId: chain.sourceId }) : null;
         const chainL1 = networkL1 ? ({ id: networkL1.chainId, ...networkL1 } as Chain) : undefined;
-        const publicClientL1 = chainL1
-            ? createPublicClient({
-                  transport: http(chainL1.rpcUrls.default.http[0]),
-                  chain: chainL1,
-              })
-            : undefined;
         const walletClientL1 = chainL1
             ? createWalletClient({
                   transport: http(chainL1.rpcUrls.default.http[0]),
@@ -136,13 +126,10 @@ export async function setupNetworksForEnv() {
 
         console.debug(`🛠️  Deploying ${network.name}`);
 
-        const result = await setupChain({
-            publicClient,
-            walletClient,
+        const result = await setupChain(walletClient, {
             bundlerAddress: bundlerAccount.address,
             verifyingSignerAddress: paymasterSignerAccount.address,
-            publicClientL1: publicClientL1 as any,
-            walletClientL1: walletClientL1 as any,
+            clientL1: walletClientL1 as any,
             bundlerTargetBalance: network.targetRelayerBalance as bigint,
             bundlerMinBalance: network.minRelayerBalance as bigint,
             paymasterTargetBalance: network.targetPaymasterBalance as bigint,

--- a/packages/contracts-account-abstraction/src/EntryPoint.test.ts
+++ b/packages/contracts-account-abstraction/src/EntryPoint.test.ts
@@ -32,18 +32,13 @@ describe("EntryPoint.test.ts", function () {
             transport,
         });
         walletClient = createWalletClient({
-            //TODO: viem mismatch
-            account: getLocalAccount(0) as unknown as Account,
+            account: getLocalAccount(0),
             chain: localhost,
             transport,
         });
 
         //Deploy DeterministicDeployer
-        //TODO: viem type mismatch
-        const { hash } = await getOrDeployDeterministicDeployer({
-            publicClient: publicClient as any,
-            walletClient: walletClient as any,
-        });
+        const { hash } = await getOrDeployDeterministicDeployer(walletClient);
         if (hash) {
             await publicClient.waitForTransactionReceipt({ hash });
         }
@@ -58,11 +53,7 @@ describe("EntryPoint.test.ts", function () {
         expect(address).toBe(entryPoint07Address);
 
         //Deploy new
-        //TODO: viem type mismatch
-        const resultDeploy = await getOrDeployDeterministicContract(
-            { publicClient: publicClient as any, walletClient: walletClient as any },
-            deployParams,
-        );
+        const resultDeploy = await getOrDeployDeterministicContract(walletClient, deployParams);
         expect(resultDeploy.address).toBe(address);
 
         //Wait for receipt
@@ -74,11 +65,7 @@ describe("EntryPoint.test.ts", function () {
         }
 
         //Get existing
-        //TODO: viem type mismatch
-        const resultGet = await getOrDeployDeterministicContract(
-            { publicClient: publicClient as any, walletClient: walletClient as any },
-            deployParams,
-        );
+        const resultGet = await getOrDeployDeterministicContract(walletClient, deployParams);
         expect(resultGet.existed).toBe(true);
         expect(resultGet.hash).toBeUndefined();
         expect(resultGet.address).toBe(address);

--- a/packages/contracts-account-abstraction/src/EntryPointSimulations.test.ts
+++ b/packages/contracts-account-abstraction/src/EntryPointSimulations.test.ts
@@ -38,18 +38,13 @@ describe("EntryPointSimulations.test.ts", function () {
                 transport,
             });
             walletClient = createWalletClient({
-                //TODO: viem type mismatch
-                account: getLocalAccount(0) as unknown as Account,
+                account: getLocalAccount(0),
                 chain: localhost,
                 transport,
             });
 
             //Deploy Deterministic Deployer first
-            //TODO: viem type mismatch
-            const { hash } = await getOrDeployDeterministicDeployer({
-                publicClient: publicClient as any,
-                walletClient: walletClient as any,
-            });
+            const { hash } = await getOrDeployDeterministicDeployer(walletClient);
             if (hash) {
                 await publicClient.waitForTransactionReceipt({ hash });
             }
@@ -63,11 +58,7 @@ describe("EntryPointSimulations.test.ts", function () {
             const address = getDeployDeterministicAddress(deployParams);
 
             //Deploy new
-            //TODO: viem type mismatch
-            const resultDeploy = await getOrDeployDeterministicContract(
-                { publicClient: publicClient as any, walletClient: walletClient as any },
-                deployParams,
-            );
+            const resultDeploy = await getOrDeployDeterministicContract(walletClient, deployParams);
             expect(resultDeploy.address).toBe(address);
 
             //Wait for receipt
@@ -79,11 +70,7 @@ describe("EntryPointSimulations.test.ts", function () {
             }
 
             //Get existing
-            //TODO: viem type mismatch
-            const resultGet = await getOrDeployDeterministicContract(
-                { publicClient: publicClient as any, walletClient: walletClient as any },
-                deployParams,
-            );
+            const resultGet = await getOrDeployDeterministicContract(walletClient, deployParams);
             expect(resultGet.existed).toBe(true);
             expect(resultGet.hash).toBeUndefined();
             expect(resultGet.address).toBe(address);

--- a/packages/contracts-account-abstraction/src/SimpleAccount.test.ts
+++ b/packages/contracts-account-abstraction/src/SimpleAccount.test.ts
@@ -49,12 +49,11 @@ describe("SimpleAccount.test.ts", function () {
             transport,
         });
         walletClient = createWalletClient({
-            //TODO: viem type mismatch
-            account: getLocalAccount(0) as unknown as HDAccount,
+            account: getLocalAccount(0),
             chain: localhost,
             transport,
         });
-        const contracts = await setupERC4337Contracts({ publicClient, walletClient: walletClient });
+        const contracts = await setupERC4337Contracts(walletClient);
         entryPoint = contracts.entrypoint.address;
         simpleAccountFactory = contracts.simpleAccountFactory.address;
     });
@@ -98,7 +97,7 @@ describe("SimpleAccount.test.ts", function () {
             expect(simpleAccountAddressOffchain).toBe(simpleAccountAddressFromFactory);
 
             //Counterfactual address no code
-            const accountExistingBytecode = await publicClient.getBytecode({ address: simpleAccountAddressOffchain });
+            const accountExistingBytecode = await publicClient.getCode({ address: simpleAccountAddressOffchain });
             expect(
                 accountExistingBytecode,
                 "Generated smart account counterfactual address should have 0x code",
@@ -115,7 +114,7 @@ describe("SimpleAccount.test.ts", function () {
             const createAccountHash = await walletClient.writeContract(createAccountRequest);
             await publicClient.waitForTransactionReceipt({ hash: createAccountHash });
 
-            const accountBytecode = await publicClient.getBytecode({ address: simpleAccountAddressOffchain });
+            const accountBytecode = await publicClient.getCode({ address: simpleAccountAddressOffchain });
             expect(accountBytecode).toBeDefined();
             const accountOwner = await publicClient.readContract({
                 address: simpleAccountAddressOffchain,

--- a/packages/contracts-account-abstraction/src/SimpleAccountFactory.test.ts
+++ b/packages/contracts-account-abstraction/src/SimpleAccountFactory.test.ts
@@ -35,17 +35,12 @@ describe("SimpleAccountFactory.test.ts", function () {
             transport,
         });
         walletClient = createWalletClient({
-            //TODO: viem type mimatch
-            account: getLocalAccount(0) as unknown as Account,
+            account: getLocalAccount(0),
             chain: localhost,
             transport,
         });
         //Deploy Deterministic Deployer first
-        //TODO: viem type mismatch
-        const { hash } = await getOrDeployDeterministicDeployer({
-            publicClient: publicClient as any,
-            walletClient: walletClient as any,
-        });
+        const { hash } = await getOrDeployDeterministicDeployer(walletClient);
         if (hash) {
             await publicClient.waitForTransactionReceipt({ hash });
         }
@@ -65,11 +60,7 @@ describe("SimpleAccountFactory.test.ts", function () {
         expect(address).toBe(SIMPLE_ACCOUNT_FACTORY_ADDRESS);
 
         //Deploy new
-        //TODO: viem type mismatch
-        const resultDeploy = await getOrDeployDeterministicContract(
-            { publicClient: publicClient as any, walletClient: walletClient as any },
-            deployParams,
-        );
+        const resultDeploy = await getOrDeployDeterministicContract(walletClient, deployParams);
         expect(resultDeploy.address).toBe(address);
 
         //Wait for receipt
@@ -81,11 +72,7 @@ describe("SimpleAccountFactory.test.ts", function () {
         }
 
         //Get existing
-        //TODO: viem type mismatch
-        const resultGet = await getOrDeployDeterministicContract(
-            { publicClient: publicClient as any, walletClient: walletClient as any },
-            deployParams,
-        );
+        const resultGet = await getOrDeployDeterministicContract(walletClient, deployParams);
         expect(resultGet.existed).toBe(true);
         expect(resultGet.hash).toBeUndefined();
         expect(resultGet.address).toBe(address);

--- a/packages/contracts-account-abstraction/src/VerifyingPaymaster.test.ts
+++ b/packages/contracts-account-abstraction/src/VerifyingPaymaster.test.ts
@@ -53,18 +53,15 @@ describe("VerifyingPaymaster.test.ts", function () {
             transport,
         });
         walletClient = createWalletClient({
-            //TODO: viem type mismatch
-            account: getLocalAccount(0) as unknown as HDAccount,
+            account: getLocalAccount(0),
             chain: localhost,
             transport,
         });
-        const contracts = await setupERC4337Contracts({ publicClient, walletClient });
+        const contracts = await setupERC4337Contracts(walletClient);
         // entryPoint = contracts.entrypoint.address;
         simpleAccountFactory = contracts.simpleAccountFactory.address;
         verifyingPaymaster = (
-            await setupVerifyingPaymaster({
-                publicClient,
-                walletClient,
+            await setupVerifyingPaymaster(walletClient, {
                 verifyingSignerAddress: walletClient.account.address,
             })
         ).address;
@@ -137,7 +134,7 @@ describe("VerifyingPaymaster.test.ts", function () {
                 },
             );
 
-            if (!(await publicClient.getBytecode({ address: simpleAccountAddress }))) {
+            if (!(await publicClient.getCode({ address: simpleAccountAddress }))) {
                 const simpleAccountFactoryData = encodeFunctionData({
                     abi: SimpleAccountFactory.abi,
                     functionName: "createAccount",

--- a/packages/contracts-account-abstraction/src/VerifyingPaymaster.test.ts
+++ b/packages/contracts-account-abstraction/src/VerifyingPaymaster.test.ts
@@ -15,7 +15,6 @@ import {
     parseEther,
     hexToBytes,
     concatHex,
-    decodeErrorResult,
     HDAccount,
     zeroAddress,
     Hash,
@@ -28,12 +27,10 @@ import { entryPoint07Address, UserOperation, getUserOperationHash } from "viem/a
 import { port } from "./test/constants.js";
 import { VerifyingPaymaster } from "./artifacts/VerifyingPaymaster.js";
 import { IEntryPoint } from "./artifacts/IEntryPoint.js";
-import { abi as EntryPointAbi } from "./artifacts/EntryPoint.js";
 import { getSimpleAccountAddress } from "./SimpleAccount.js";
 import { ERC1967Proxy } from "./artifacts/ERC1967Proxy.js";
 import { SimpleAccountFactory } from "./artifacts/SimpleAccountFactory.js";
 import { dummySignature, encodeUserOp } from "./models/UserOperation.js";
-import { decodeViemError } from "./isViemError.js";
 import { setupERC4337Contracts, setupVerifyingPaymaster } from "./setupERC4337Contracts.js";
 import { toPackedUserOperation } from "./models/PackedUserOperation.js";
 import { getVerifyingPaymasterHash } from "./VerifyingPaymaster.js";
@@ -67,7 +64,7 @@ describe("VerifyingPaymaster.test.ts", function () {
         ).address;
     });
 
-    test.only("getVerifyingPaymasterHash", async () => {
+    test("getVerifyingPaymasterHash", async () => {
         const validUntil = Date.now() + 3600;
         const validAfter = 0;
         const paymasterDataUnsigned = encodeAbiParameters(
@@ -171,8 +168,8 @@ describe("VerifyingPaymaster.test.ts", function () {
          **/
         test("submitUserOp - manual", async () => {
             //Create UserOp
-            //Encode smart account tx, send mock to vitalik
-            const to = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; // vitalik
+            //Encode smart account tx, send to random address
+            const to = privateKeyToAccount(generatePrivateKey()).address;
             const value = 1n;
             const data = "0x";
             const callData = encodeFunctionData({
@@ -274,36 +271,21 @@ describe("VerifyingPaymaster.test.ts", function () {
             await publicClient.waitForTransactionReceipt({ hash: paymasterDepositHash });
 
             //Simulate handleOps
-            try {
-                const { request } = await publicClient.simulateContract({
-                    account: walletClient.account,
-                    address: entryPoint07Address,
-                    abi: IEntryPoint.abi,
-                    functionName: "handleOps",
-                    args: handleOpsArgs,
-                });
+            const { request } = await publicClient.simulateContract({
+                account: walletClient.account,
+                address: entryPoint07Address,
+                abi: IEntryPoint.abi,
+                functionName: "handleOps",
+                args: handleOpsArgs,
+            });
 
-                //Sumbit UserOp
-                const handleOpsHash = await walletClient.writeContract(request as any);
-                await publicClient.waitForTransactionReceipt({ hash: handleOpsHash });
+            //Sumbit UserOp
+            const handleOpsHash = await walletClient.writeContract(request as any);
+            await publicClient.waitForTransactionReceipt({ hash: handleOpsHash });
 
-                //Get balanceOf vitalik
-                const balance = await publicClient.getBalance({ address: to });
-                expect(balance).toBeGreaterThanOrEqual(value);
-            } catch (err: any) {
-                const errorEntryPoint = decodeViemError(err, EntryPointAbi);
-                if (errorEntryPoint) {
-                    console.error(errorEntryPoint);
-                    if (errorEntryPoint.errorName === "FailedOpWithRevert") {
-                        const errorPaymaster = decodeErrorResult({
-                            abi: VerifyingPaymaster.abi,
-                            data: errorEntryPoint.args[2],
-                        });
-                        console.error(errorPaymaster);
-                    }
-                }
-                throw err;
-            }
+            //Get balanceOf vitalik
+            const balance = await publicClient.getBalance({ address: to });
+            expect(balance).toBe(value);
         });
     });
 });

--- a/packages/contracts-account-abstraction/src/eip1193/createBundlerEIP1193.test.ts
+++ b/packages/contracts-account-abstraction/src/eip1193/createBundlerEIP1193.test.ts
@@ -69,16 +69,13 @@ describe("eip1993/createBundlerEIP1193.test.ts", function () {
             transport,
         });
         walletClient = createWalletClient({
-            account: getLocalAccount(0) as unknown as HDAccount,
+            account: getLocalAccount(0),
             chain: localhost,
             transport,
         });
 
         // ERC4337 Contracts
-        const contracts = await setupERC4337Contracts({
-            publicClient,
-            walletClient,
-        });
+        const contracts = await setupERC4337Contracts(walletClient);
         entryPointAddress = contracts.entrypoint.address;
         entryPointSimulationsAddress = contracts.pimlicoEntrypointSimulations.address;
         factoryAddress = contracts.simpleAccountFactory.address;
@@ -174,7 +171,7 @@ describe("eip1993/createBundlerEIP1193.test.ts", function () {
             const receipt = await publicClient.waitForTransactionReceipt({ hash });
             expect(receipt).toBeDefined();
 
-            const contractBytecode = await publicClient.getBytecode({ address: contractAddressExpected });
+            const contractBytecode = await publicClient.getCode({ address: contractAddressExpected });
             expect(contractBytecode).toBeDefined();
         });
 
@@ -187,7 +184,7 @@ describe("eip1993/createBundlerEIP1193.test.ts", function () {
             const userOpReceipt = await waitForUserOperationReceipt(bundlerClient, { hash: userOpHash });
             expect(userOpReceipt).toBeDefined();
 
-            const contractBytecode = await publicClient.getBytecode({ address: contractAddressExpected });
+            const contractBytecode = await publicClient.getCode({ address: contractAddressExpected });
             expect(contractBytecode).toBeDefined();
         });
     });

--- a/packages/contracts-account-abstraction/src/eip1193/createPaymasterEIP1193.test.ts
+++ b/packages/contracts-account-abstraction/src/eip1193/createPaymasterEIP1193.test.ts
@@ -78,32 +78,25 @@ describe("eip1993/createPaymasterEIP1193.test.ts", function () {
             transport,
         });
         walletClient = createWalletClient({
-            account: getLocalAccount(0) as unknown as HDAccount,
+            account: getLocalAccount(0),
             chain: localhost,
             transport,
         });
 
         // ERC4337 Contracts
-        const contracts = await setupERC4337Contracts({
-            publicClient,
-            walletClient,
-        });
+        const contracts = await setupERC4337Contracts(walletClient);
         entryPointAddress = contracts.entrypoint.address;
         entryPointSimulationsAddress = contracts.pimlicoEntrypointSimulations.address;
         factoryAddress = contracts.simpleAccountFactory.address;
 
         // Paymaster
         paymasterAddress = (
-            await setupVerifyingPaymaster({
-                publicClient,
-                walletClient,
+            await setupVerifyingPaymaster(walletClient, {
                 verifyingSignerAddress: walletClient.account.address,
             })
         ).address;
 
-        const { hash: topupHash } = await topupPaymaster({
-            publicClient,
-            walletClient,
+        const { hash: topupHash } = await topupPaymaster(walletClient, {
             paymaster: paymasterAddress,
             minBalance: parseEther("10"),
         });
@@ -211,7 +204,7 @@ describe("eip1993/createPaymasterEIP1193.test.ts", function () {
             const receipt = await publicClient.waitForTransactionReceipt({ hash });
             expect(receipt).toBeDefined();
 
-            const contractBytecode = await publicClient.getBytecode({ address: contractAddressExpected });
+            const contractBytecode = await publicClient.getCode({ address: contractAddressExpected });
             expect(contractBytecode).toBeDefined();
         });
 
@@ -225,7 +218,7 @@ describe("eip1993/createPaymasterEIP1193.test.ts", function () {
             const userOpReceipt = await waitForUserOperationReceipt(bundlerClient, { hash: userOpHash });
             expect(userOpReceipt).toBeDefined();
 
-            const contractBytecode = await publicClient.getBytecode({ address: contractAddressExpected });
+            const contractBytecode = await publicClient.getCode({ address: contractAddressExpected });
             expect(contractBytecode).toBeDefined();
         });
     });

--- a/packages/contracts-account-abstraction/src/setupERC4337Contracts.test.ts
+++ b/packages/contracts-account-abstraction/src/setupERC4337Contracts.test.ts
@@ -25,40 +25,30 @@ describe("setupERC4337Contracts.test.ts", function () {
             transport,
         });
         walletClient = createWalletClient({
-            //TODO: viem type mismatch
-            account: getLocalAccount(0) as unknown as Account,
+            account: getLocalAccount(0),
             chain: localhost,
             transport,
         });
 
         //Deploy Deterministic Deployer first
-        const { hash } = await getOrDeployDeterministicDeployer({
-            //TOOD: viem type mismatch
-            publicClient: publicClient as any,
-            walletClient: walletClient as any,
-        });
+        const { hash } = await getOrDeployDeterministicDeployer(walletClient);
         if (hash) {
             await publicClient.waitForTransactionReceipt({ hash });
         }
     });
 
     test("setupERC4337Contracts", async () => {
-        const result = await setupERC4337Contracts({
-            publicClient,
-            walletClient,
-        });
+        const result = await setupERC4337Contracts(walletClient);
 
-        expect(await publicClient.getBytecode({ address: result.deterministicDeployer.address })).toBeDefined();
-        expect(await publicClient.getBytecode({ address: result.entrypoint.address })).toBeDefined();
-        expect(await publicClient.getBytecode({ address: result.simpleAccountFactory.address })).toBeDefined();
-        expect(await publicClient.getBytecode({ address: result.entrypointSimulations.address })).toBeDefined();
-        expect(await publicClient.getBytecode({ address: result.pimlicoEntrypointSimulations.address })).toBeDefined();
+        expect(await publicClient.getCode({ address: result.deterministicDeployer.address })).toBeDefined();
+        expect(await publicClient.getCode({ address: result.entrypoint.address })).toBeDefined();
+        expect(await publicClient.getCode({ address: result.simpleAccountFactory.address })).toBeDefined();
+        expect(await publicClient.getCode({ address: result.entrypointSimulations.address })).toBeDefined();
+        expect(await publicClient.getCode({ address: result.pimlicoEntrypointSimulations.address })).toBeDefined();
 
-        const verifyingPaymaster = await setupVerifyingPaymaster({
-            publicClient,
-            walletClient,
+        const verifyingPaymaster = await setupVerifyingPaymaster(walletClient, {
             verifyingSignerAddress: walletClient.account.address,
         });
-        expect(await publicClient.getBytecode({ address: verifyingPaymaster.address })).toBeDefined();
+        expect(await publicClient.getCode({ address: verifyingPaymaster.address })).toBeDefined();
     });
 });

--- a/packages/contracts-create2factory/src/Create2Factory/deployCreate2Factory.ts
+++ b/packages/contracts-create2factory/src/Create2Factory/deployCreate2Factory.ts
@@ -1,8 +1,9 @@
-import { Hash, zeroHash } from "viem";
+import { Account, Chain, Client, Hash, Transport, zeroHash } from "viem";
 import { getDeployDeterministicFunctionData, DETERMINISTIC_DEPLOYER_ADDRESS } from "@owlprotocol/viem-utils";
+import { getAction } from "viem/utils";
+import { getCode, sendTransaction } from "viem/actions";
 import { CREATE2_FACTORY_ADDRESS } from "./constants.js";
 import { Create2Factory } from "../artifacts/Create2Factory.js";
-import { Clients } from "../clients.js";
 
 //Check if already deployed
 
@@ -10,27 +11,31 @@ import { Clients } from "../clients.js";
  * Deploy Create2Factory with DeterministicDeployer
  * Create2Factory can be deployed in 2 ways:
  *   - CREATE2 DeterministicDeployer at 0x4e59b44847b379578588920cA78FbF26c0B4956C (recommended)
- * @param clients publicClient, walletClient to fund deploy transaction (deterministic)
+ * @param client Client with chain & account to fund deploy transaction (deterministic)
  * @returns
  */
-export async function deployCreate2FactoryWithTx(clients: Omit<Clients, "publicClient">): Promise<Hash> {
-    const { walletClient } = clients;
+export async function deployCreate2FactoryWithTx(client: Client<Transport, Chain, Account>): Promise<Hash> {
     const { to, data } = getDeployDeterministicFunctionData({ salt: zeroHash, bytecode: Create2Factory.bytecode });
-    return walletClient.sendTransaction({
+    return getAction(
+        client,
+        sendTransaction,
+        "sendTransaction",
+    )({
         to,
         data,
+        account: client.account,
+        chain: client.chain,
     });
 }
 
 /**
  * Higher-level wrapper around `deployCreate2FactoryWithTx`, common use case in hardhat with viem
- * @param clients publicClient, walletClient
+ * @param client Client with chain & account
  * @returns
  */
-export async function getOrDeployCreate2Factory(clients: Clients) {
-    const { publicClient } = clients;
+export async function getOrDeployCreate2Factory(client: Client<Transport, Chain, Account>) {
     //Check if Create2Factory exists
-    const existingByteCode = await publicClient.getBytecode({ address: CREATE2_FACTORY_ADDRESS });
+    const existingByteCode = await getAction(client, getCode, "getCode")({ address: CREATE2_FACTORY_ADDRESS });
     if (existingByteCode != undefined) {
         return {
             address: CREATE2_FACTORY_ADDRESS,
@@ -40,13 +45,13 @@ export async function getOrDeployCreate2Factory(clients: Clients) {
     }
 
     //Make sure DeterministicDeployer exists
-    if ((await publicClient.getBytecode({ address: DETERMINISTIC_DEPLOYER_ADDRESS })) === undefined) {
+    if ((await getAction(client, getCode, "getCode")({ address: DETERMINISTIC_DEPLOYER_ADDRESS })) === undefined) {
         throw new Error(
             `DeterministicDeployer not deployed at ${DETERMINISTIC_DEPLOYER_ADDRESS}! Please deploy DeterministicDeployer first or use pre-signed deployment.`,
         );
     }
 
-    const hash = await deployCreate2FactoryWithTx(clients);
+    const hash = await deployCreate2FactoryWithTx(client);
     return {
         address: CREATE2_FACTORY_ADDRESS,
         hash,

--- a/packages/contracts-create2factory/src/Create2Factory/getTransaction.ts
+++ b/packages/contracts-create2factory/src/Create2Factory/getTransaction.ts
@@ -1,9 +1,10 @@
 import { fromPairs, zip } from "lodash-es";
-import { Address, Hash, encodeFunctionData, zeroAddress, zeroHash } from "viem";
+import { Account, Address, Chain, Client, Hash, Transport, encodeFunctionData, zeroAddress, zeroHash } from "viem";
+import { getCode, simulateContract, writeContract } from "viem/actions";
+import { getAction } from "viem/utils";
 import { CREATE2_FACTORY_ADDRESS } from "./constants.js";
 import { ContractCreateArgs, getDeployAddress } from "./getAddress.js";
 import { ICreate2Factory } from "../artifacts/ICreate2Factory.js";
-import { Clients } from "../clients.js";
 
 /**
  * Get transaction data for deploying a batch of smart contracts
@@ -39,7 +40,7 @@ export function getDeployFunctionData(
  * @returns creation args (for new contracts), addresses (for new contracts), addressesAll (includes existing)
  */
 export async function getDeployContractsParams(
-    { publicClient }: Pick<Clients, "publicClient">,
+    client: Client,
     msgSender: Address,
     contracts: ContractCreateArgs[],
     create2FactoryAddress = CREATE2_FACTORY_ADDRESS,
@@ -58,7 +59,7 @@ export async function getDeployContractsParams(
     const addressesAll: { address: Address; exists: boolean }[] = [];
     for (const contract of contracts) {
         const address = getDeployAddress(msgSender, contract, create2FactoryAddress);
-        const bytecode = await publicClient.getBytecode({ address });
+        const bytecode = await getAction(client, getCode, "getCode")({ address });
         addressesAll.push({ address, exists: bytecode != undefined });
     }
     //console.debug(address, addressExists);
@@ -77,51 +78,54 @@ export async function getDeployContractsParams(
 /**
  * Deploy contracts, we recommend calling `getDeployContractsParams()` beforehand to
  * filter out contracts that are already deployed to save gas.
- * @param clients walletClient, publicClient
+ * @param client Client with chain & account
  * @param msgSender msg.sender or address(0)
  * @param contracts creation args for each contract
  * @param create2FactoryAddress
  * @returns deploy transaction hash
  */
 export async function deployContracts(
-    clients: Clients,
+    client: Client<Transport, Chain, Account>,
     msgSender: Address,
     contracts: ContractCreateArgs[],
     create2FactoryAddress = CREATE2_FACTORY_ADDRESS,
 ) {
     if (contracts.length === 0) throw new Error("contracts.length == 0");
 
-    const { publicClient, walletClient } = clients;
-
-    const { request } = await publicClient.simulateContract({
+    const { request } = await getAction(
+        client,
+        simulateContract,
+        "simulateContract",
+    )({
         address: create2FactoryAddress,
         abi: ICreate2Factory.abi,
         functionName: "create",
         //TODO: Type inference incorrect for some reason
         args: [msgSender, contracts as any],
-        account: walletClient.account,
+        account: client.account,
+        chain: client.chain,
     });
 
-    return walletClient.writeContract(request);
+    return getAction(client, writeContract, "writeContract")(request);
 }
 
 /**
  * Call `deployContracts(getDeployContractsParams(...))`
  * Deploys contracts that don't exist and computes addresses for all
- * @param clients walletClient, publicClient
+ * @param client Client with chain & account
  * @param msgSender msg.sender or address(0)
  * @param contracts creation args for each contract
  * @param create2FactoryAddress
  * @returns deploy transaction hash
  */
 export async function getOrDeployContracts(
-    clients: Clients,
+    client: Client<Transport, Chain, Account>,
     msgSender: Address,
     contracts: ContractCreateArgs[],
     create2FactoryAddress = CREATE2_FACTORY_ADDRESS,
 ) {
     const { contractsNew, addressesAll } = await getDeployContractsParams(
-        clients,
+        client,
         msgSender,
         contracts,
         create2FactoryAddress,
@@ -129,7 +133,7 @@ export async function getOrDeployContracts(
 
     let hash: Hash | undefined;
     if (contractsNew.length > 0) {
-        hash = await deployContracts(clients, msgSender, contractsNew, create2FactoryAddress);
+        hash = await deployContracts(client, msgSender, contractsNew, create2FactoryAddress);
     }
 
     return {
@@ -143,19 +147,19 @@ export async function getOrDeployContracts(
  *   - msgSender is set to address(0)
  *   - salt is set to bytes32(0)
  *   - initData is set to 0x
- * @param clients walletClient, publicClient
+ * @param client Client with chain & account
  * @param msgSender msg.sender or address(0)
  * @param contracts creation args for each contract
  * @param create2FactoryAddress
  * @returns deploy transaction hash
  */
 export async function getOrDeployImplementations(
-    clients: Clients,
+    client: Client<Transport, Chain, Account>,
     contracts: Omit<ContractCreateArgs, "salt" | "initData">[],
     create2FactoryAddress = CREATE2_FACTORY_ADDRESS,
 ) {
     return getOrDeployContracts(
-        clients,
+        client,
         zeroAddress,
         contracts.map((c) => {
             return { salt: zeroHash, bytecode: c.bytecode, initData: "0x" };
@@ -166,7 +170,7 @@ export async function getOrDeployImplementations(
 
 /**
  * Call `getOrDeployContracts` but return as keyvalue
- * @param clients walletClient, publicClient
+ * @param client Client with chain & account
  * @param msgSender msg.sender or address(0)
  * @param contracts creation args for each contract
  * @param create2FactoryAddress
@@ -174,13 +178,13 @@ export async function getOrDeployImplementations(
  */
 export async function getOrDeployContractsObj<
     T extends Record<string, ContractCreateArgs> = Record<string, ContractCreateArgs>,
->(clients: Clients, msgSender: Address, contracts: T, create2FactoryAddress = CREATE2_FACTORY_ADDRESS) {
-    const resultDeploy = await getOrDeployContracts(
-        clients,
-        msgSender,
-        Object.values(contracts),
-        create2FactoryAddress,
-    );
+>(
+    client: Client<Transport, Chain, Account>,
+    msgSender: Address,
+    contracts: T,
+    create2FactoryAddress = CREATE2_FACTORY_ADDRESS,
+) {
+    const resultDeploy = await getOrDeployContracts(client, msgSender, Object.values(contracts), create2FactoryAddress);
 
     const addresses = fromPairs(
         zip(

--- a/packages/contracts-create2factory/src/Create2Factory/index.test.ts
+++ b/packages/contracts-create2factory/src/Create2Factory/index.test.ts
@@ -42,7 +42,7 @@ describe.skip("deployCreate2Factory.test.ts", function () {
         });
 
         //Deploy DeterministicDeployer
-        const { hash } = await getOrDeployDeterministicDeployer({ publicClient, walletClient });
+        const { hash } = await getOrDeployDeterministicDeployer(walletClient);
         if (hash) {
             await publicClient.waitForTransactionReceipt({ hash });
         }
@@ -59,10 +59,7 @@ describe.skip("deployCreate2Factory.test.ts", function () {
 
     test("getOrDeployContracts", async () => {
         //Deploy Create2Factory
-        const resultDeployCreate2Factory = await getOrDeployCreate2Factory({
-            publicClient,
-            walletClient,
-        });
+        const resultDeployCreate2Factory = await getOrDeployCreate2Factory(walletClient);
         expect(resultDeployCreate2Factory.address).toBe(CREATE2_FACTORY_ADDRESS);
 
         //Wait for receipt
@@ -73,7 +70,7 @@ describe.skip("deployCreate2Factory.test.ts", function () {
         }
 
         //Get existing Create2Factory
-        const resultGetCreate2Factory = await getOrDeployCreate2Factory({ publicClient, walletClient });
+        const resultGetCreate2Factory = await getOrDeployCreate2Factory(walletClient);
         expect(resultGetCreate2Factory.existed).toBe(true);
         expect(resultGetCreate2Factory.hash).toBeUndefined();
         expect(resultGetCreate2Factory.address).toBe(CREATE2_FACTORY_ADDRESS);
@@ -83,9 +80,7 @@ describe.skip("deployCreate2Factory.test.ts", function () {
         const contractArgs = { bytecode: MyContract.bytecode, initData: "0x" as Hex, salt: zeroHash };
         const address = getDeployAddress(msgSender, contractArgs);
 
-        const resultDeployMyContract = await getOrDeployContracts({ publicClient, walletClient }, zeroAddress, [
-            contractArgs,
-        ]);
+        const resultDeployMyContract = await getOrDeployContracts(walletClient, zeroAddress, [contractArgs]);
         expect(resultDeployMyContract.addresses[0].address).toBe(address);
 
         //Wait for receipt
@@ -96,9 +91,7 @@ describe.skip("deployCreate2Factory.test.ts", function () {
         }
 
         //Get existing MyContract
-        const resultGetMyContract = await getOrDeployContracts({ publicClient, walletClient }, msgSender, [
-            contractArgs,
-        ]);
+        const resultGetMyContract = await getOrDeployContracts(walletClient, msgSender, [contractArgs]);
         expect(resultGetMyContract.hash).toBeUndefined();
         expect(resultGetMyContract.addresses[0].address).toBe(address);
         expect(resultGetMyContract.addresses[0].exists).toBe(true);

--- a/packages/contracts-create2factory/src/clients.ts
+++ b/packages/contracts-create2factory/src/clients.ts
@@ -1,6 +1,0 @@
-import { Account, Chain, PublicClient, Transport, WalletClient } from "viem";
-
-export type Clients = {
-    publicClient: PublicClient<Transport, Chain>;
-    walletClient: WalletClient<Transport, Chain, Account>;
-};

--- a/packages/contracts-diamond/src/Diamond.test.ts
+++ b/packages/contracts-diamond/src/Diamond.test.ts
@@ -50,21 +50,18 @@ describe("Diamond.test.ts", function () {
             transport,
         });
         //Deploy DeterministicDeployer
-        const { hash: hash0 } = await getOrDeployDeterministicDeployer({
-            publicClient,
-            walletClient: localWalletClient,
-        });
+        const { hash: hash0 } = await getOrDeployDeterministicDeployer(localWalletClient);
         if (hash0) {
             await publicClient.waitForTransactionReceipt({ hash: hash0 });
         }
         //Deploy Create2Factory
-        const { hash: hash1 } = await getOrDeployCreate2Factory({ publicClient, walletClient: localWalletClient });
+        const { hash: hash1 } = await getOrDeployCreate2Factory(localWalletClient);
         if (hash1) {
             await publicClient.waitForTransactionReceipt({ hash: hash1 });
         }
 
         //Deploy implementations
-        const resultDeployFacets = await getOrDeployImplementations({ publicClient, walletClient: localWalletClient }, [
+        const resultDeployFacets = await getOrDeployImplementations(localWalletClient, [
             { bytecode: DiamondCutFacet.bytecode },
             { bytecode: DiamondLoupeFacet.bytecode },
             { bytecode: MyContract.bytecode },
@@ -83,9 +80,7 @@ describe("Diamond.test.ts", function () {
         });
 
         //Top-up EOA address
-        const { hash } = await topupAddress({
-            publicClient,
-            walletClient: localWalletClient,
+        const { hash } = await topupAddress(localWalletClient, {
             address: walletClient.account.address,
             minBalance: parseEther("10"),
             targetBalance: parseEther("10"),
@@ -116,7 +111,7 @@ describe("Diamond.test.ts", function () {
             initData: "0x",
         });
 
-        const resultDeploy = await getOrDeployContracts({ publicClient, walletClient }, zeroAddress, [
+        const resultDeploy = await getOrDeployContracts(walletClient, zeroAddress, [
             {
                 salt: zeroHash,
                 bytecode: diamondDeployData.deployData,

--- a/packages/contracts-diamond/src/Diamond.ts
+++ b/packages/contracts-diamond/src/Diamond.ts
@@ -1,5 +1,4 @@
-import { Clients } from "@owlprotocol/contracts-create2factory";
-import { Abi, Address, Hex, encodeDeployData, encodeFunctionData, toFunctionSelector, zeroAddress } from "viem";
+import { Abi, Address, Client, Hex, encodeDeployData, encodeFunctionData, toFunctionSelector, zeroAddress } from "viem";
 import { Diamond, DiamondInitMulti } from "./artifacts/index.js";
 
 export function getAbiFunctionSelectors(abi: Abi): Hex[] {
@@ -56,7 +55,7 @@ export function validateDiamondCutUpgrades(
  * @returns
  */
 export async function getDiamondCutUpgrades(
-    _clients: Pick<Clients, "publicClient">,
+    _clients: Client,
     facets: { facetAddress: Address; functionSelectors: Hex[] }[],
 ): Promise<{ facetAddress: Address; functionSelectors: Hex[]; action: FacetCutAction }[]> {
     //TODO: Add logic above, for now just return all

--- a/packages/contracts-diamond/src/ERC721.test.ts
+++ b/packages/contracts-diamond/src/ERC721.test.ts
@@ -45,20 +45,17 @@ describe("ERC721.test.ts", function () {
             transport,
         });
         //Deploy DeterministicDeployer
-        const { hash: hash0 } = await getOrDeployDeterministicDeployer({
-            publicClient,
-            walletClient: localWalletClient,
-        });
+        const { hash: hash0 } = await getOrDeployDeterministicDeployer(localWalletClient);
         if (hash0) {
             await publicClient.waitForTransactionReceipt({ hash: hash0 });
         }
         //Deploy Create2Factory
-        const { hash: hash1 } = await getOrDeployCreate2Factory({ publicClient, walletClient: localWalletClient });
+        const { hash: hash1 } = await getOrDeployCreate2Factory(localWalletClient);
         if (hash1) {
             await publicClient.waitForTransactionReceipt({ hash: hash1 });
         }
         //Deploy implementations
-        const { deployTransaction } = await getERC721ImplementationDeployParams({ publicClient });
+        const { deployTransaction } = await getERC721ImplementationDeployParams(publicClient);
         if (deployTransaction) {
             const deployFacetsHash = await localWalletClient.sendTransaction(deployTransaction);
             await publicClient.waitForTransactionReceipt({ hash: deployFacetsHash });
@@ -73,9 +70,7 @@ describe("ERC721.test.ts", function () {
         });
 
         //Top-up EOA address
-        const { hash } = await topupAddress({
-            publicClient,
-            walletClient: localWalletClient,
+        const { hash } = await topupAddress(localWalletClient, {
             address: walletClient.account.address,
             minBalance: parseEther("10"),
             targetBalance: parseEther("10"),
@@ -101,10 +96,10 @@ describe("ERC721.test.ts", function () {
             initData: "0x",
         });
 
-        const diamondBytecode = await publicClient.getBytecode({ address: diamondAddress });
+        const diamondBytecode = await publicClient.getCode({ address: diamondAddress });
         expect(diamondBytecode).toBeUndefined();
 
-        const resultDeploy = await getOrDeployContracts({ publicClient, walletClient }, zeroAddress, [
+        const resultDeploy = await getOrDeployContracts(walletClient, zeroAddress, [
             {
                 salt: zeroHash,
                 bytecode: diamondDeployData.deployData,
@@ -118,7 +113,7 @@ describe("ERC721.test.ts", function () {
             await publicClient.waitForTransactionReceipt({ hash: resultDeploy.hash });
         }
 
-        const diamondBytecode2 = await publicClient.getBytecode({ address: diamondAddress });
+        const diamondBytecode2 = await publicClient.getCode({ address: diamondAddress });
         expect(diamondBytecode2).toBeDefined();
 
         const symbol = await publicClient.readContract({

--- a/packages/contracts-diamond/src/ERC721.ts
+++ b/packages/contracts-diamond/src/ERC721.ts
@@ -1,5 +1,5 @@
-import { Clients, getDeployContractsParams, getDeployFunctionData } from "@owlprotocol/contracts-create2factory";
-import { Address, Hex, zeroAddress, zeroHash } from "viem";
+import { getDeployContractsParams, getDeployFunctionData } from "@owlprotocol/contracts-create2factory";
+import { Address, Client, Hex, zeroAddress, zeroHash } from "viem";
 import { getAbiFunctionSelectors, getDiamondDeployData } from "./Diamond.js";
 
 import {
@@ -68,7 +68,7 @@ export function getERC721DiamondDeployData(initParams: ERC721DiamondInitParams &
     };
 }
 
-export async function getERC721ImplementationDeployParams(clients: Pick<Clients, "publicClient">) {
+export async function getERC721ImplementationDeployParams(client: Client) {
     const artifacts = [
         ...Object.values(ERC721PresetDiamondSpec.facets),
         ...Object.values(ERC721PresetDiamondSpec.initializers),
@@ -79,7 +79,7 @@ export async function getERC721ImplementationDeployParams(clients: Pick<Clients,
     // - Diamond inits (delegate call post-cut)
     // `getDeployContractsParams` returns only contracts required for deployment
     const deployParams = await getDeployContractsParams(
-        clients,
+        client,
         zeroAddress,
         Object.values(artifacts).map((a) => {
             return { salt: zeroHash, bytecode: a.bytecode, initData: "0x" };

--- a/packages/contracts-hyperlane/src/mailbox/getOrDeployMailboxImpl.ts
+++ b/packages/contracts-hyperlane/src/mailbox/getOrDeployMailboxImpl.ts
@@ -1,25 +1,20 @@
 import { getOrDeployDeterministicContract } from "@owlprotocol/viem-utils";
-import { zeroHash, PublicClient, Transport, Chain, WalletClient, Account, Hash, Address, encodeDeployData } from "viem";
+import { zeroHash, Transport, Chain, Account, Hash, Address, encodeDeployData, Client } from "viem";
 import { Mailbox } from "../artifacts/Mailbox.js";
 
-export async function getOrDeployMailboxImpl({
-    publicClient,
-    walletClient,
-    salt = zeroHash,
-}: {
-    publicClient: PublicClient<Transport, Chain>;
-    walletClient: WalletClient<Transport, Chain, Account>;
-    salt?: Hash;
-}): Promise<{ hash?: Hash; address: Address }> {
-    return getOrDeployDeterministicContract(
-        { publicClient, walletClient },
-        {
-            salt,
-            bytecode: encodeDeployData({
-                abi: Mailbox.abi,
-                bytecode: Mailbox.bytecode,
-                args: [publicClient.chain.id],
-            }),
-        },
-    );
+export async function getOrDeployMailboxImpl(
+    client: Client<Transport, Chain, Account>,
+    parameters?: {
+        salt?: Hash;
+    },
+): Promise<{ hash?: Hash; address: Address }> {
+    const { salt = zeroHash } = parameters ?? {};
+    return getOrDeployDeterministicContract(client, {
+        salt,
+        bytecode: encodeDeployData({
+            abi: Mailbox.abi,
+            bytecode: Mailbox.bytecode,
+            args: [client.chain.id],
+        }),
+    });
 }

--- a/packages/contracts-hyperlane/src/mailbox/getOrDeployMailboxProxy.ts
+++ b/packages/contracts-hyperlane/src/mailbox/getOrDeployMailboxProxy.ts
@@ -1,42 +1,25 @@
 import { getOrDeployContracts, getCloneDeterministicBytecode } from "@owlprotocol/contracts-create2factory";
-import {
-    zeroHash,
-    PublicClient,
-    Transport,
-    Chain,
-    WalletClient,
-    Account,
-    Address,
-    Hash,
-    zeroAddress,
-    encodeFunctionData,
-} from "viem";
+import { zeroHash, Transport, Chain, Account, Address, Hash, zeroAddress, encodeFunctionData, Client } from "viem";
 import { initialize as initializeAbi } from "../artifacts/Mailbox.js";
 
-export async function getOrDeployMailboxProxy({
-    publicClient,
-    walletClient,
-    mailboxImplAddress,
-    ismAddress,
-    defaultHookAddress,
-    requiredHookAddress,
-    salt = zeroHash,
-}: {
-    publicClient: PublicClient<Transport, Chain>;
-    walletClient: WalletClient<Transport, Chain, Account>;
-    mailboxImplAddress: Address;
-    ismAddress: Address;
-    defaultHookAddress: Address;
-    requiredHookAddress: Address;
-    salt?: Hash;
-}): Promise<{ hash?: Hash; address: Address; exists: boolean }> {
-    const deployMailbox = await getOrDeployContracts({ publicClient, walletClient }, zeroAddress, [
+export async function getOrDeployMailboxProxy(
+    client: Client<Transport, Chain, Account>,
+    parameters: {
+        mailboxImplAddress: Address;
+        ismAddress: Address;
+        defaultHookAddress: Address;
+        requiredHookAddress: Address;
+        salt?: Hash;
+    },
+): Promise<{ hash?: Hash; address: Address; exists: boolean }> {
+    const { mailboxImplAddress, ismAddress, defaultHookAddress, requiredHookAddress, salt = zeroHash } = parameters;
+    const deployMailbox = await getOrDeployContracts(client, zeroAddress, [
         {
             bytecode: getCloneDeterministicBytecode(mailboxImplAddress),
             initData: encodeFunctionData({
                 abi: [initializeAbi],
                 functionName: "initialize",
-                args: [walletClient.account.address, ismAddress, defaultHookAddress, requiredHookAddress],
+                args: [client.account.address, ismAddress, defaultHookAddress, requiredHookAddress],
             }),
             salt,
         },

--- a/packages/contracts-hyperlane/src/test/mailboxTestHelpers.ts
+++ b/packages/contracts-hyperlane/src/test/mailboxTestHelpers.ts
@@ -1,112 +1,107 @@
-import { Clients, getOrDeployDeterministicContract, getOrDeployDeterministicDeployer } from "@owlprotocol/viem-utils";
-import { Account, Address, Chain, Hex, PublicClient, Transport, WalletClient, zeroHash } from "viem";
+import { getOrDeployDeterministicContract, getOrDeployDeterministicDeployer } from "@owlprotocol/viem-utils";
+import { Account, Address, Chain, Client, Hex, Transport, zeroHash } from "viem";
 import { getOrDeployCreate2Factory } from "@owlprotocol/contracts-create2factory";
+import { waitForTransactionReceipt } from "viem/actions";
+import { getAction } from "viem/utils";
 import { NoopIsm } from "../artifacts/NoopIsm.js";
 import { PausableHook } from "../artifacts/PausableHook.js";
 import { TestRecipient } from "../artifacts/TestRecipient.js";
 import { getOrDeployMailboxImpl } from "../mailbox/getOrDeployMailboxImpl.js";
 import { getOrDeployMailboxProxy } from "../mailbox/getOrDeployMailboxProxy.js";
 
-export async function getOrDeployTestIsm(params: Clients) {
-    const { walletClient, publicClient } = params;
-    return getOrDeployDeterministicContract(
-        { publicClient, walletClient },
-        { salt: zeroHash, bytecode: NoopIsm.bytecode },
-    );
+export async function getOrDeployTestIsm(client: Client<Transport, Chain, Account>) {
+    return getOrDeployDeterministicContract(client, { salt: zeroHash, bytecode: NoopIsm.bytecode });
 }
 
-export async function getOrDeployTestHook(params: Clients) {
-    const { walletClient, publicClient } = params;
-    return getOrDeployDeterministicContract(
-        { publicClient, walletClient },
-        {
-            salt: zeroHash,
-            bytecode: PausableHook.bytecode,
-        },
-    );
+export async function getOrDeployTestHook(client: Client<Transport, Chain, Account>) {
+    return getOrDeployDeterministicContract(client, {
+        salt: zeroHash,
+        bytecode: PausableHook.bytecode,
+    });
 }
 
-export async function setupTestMailboxContracts(clients: Clients) {
-    const { publicClient } = clients;
-
-    const deterministicDeployer = await getOrDeployDeterministicDeployer(clients);
+export async function setupTestMailboxContracts(client: Client<Transport, Chain, Account>) {
+    const deterministicDeployer = await getOrDeployDeterministicDeployer(client);
     if (deterministicDeployer.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: deterministicDeployer.hash });
+        await getAction(
+            client,
+            waitForTransactionReceipt,
+            "waitForTransactionReceipt",
+        )({ hash: deterministicDeployer.hash });
     }
 
-    const create2Factory = await getOrDeployCreate2Factory(clients);
+    const create2Factory = await getOrDeployCreate2Factory(client);
     if (create2Factory.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: create2Factory.hash });
+        await getAction(client, waitForTransactionReceipt, "waitForTransactionReceipt")({ hash: create2Factory.hash });
     }
 
-    const testIsm = await getOrDeployTestIsm(clients);
+    const testIsm = await getOrDeployTestIsm(client);
     if (testIsm.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: testIsm.hash });
+        await getAction(client, waitForTransactionReceipt, "waitForTransactionReceipt")({ hash: testIsm.hash });
     }
 
-    const testHook = await getOrDeployTestHook(clients);
+    const testHook = await getOrDeployTestHook(client);
     if (testHook.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: testHook.hash });
+        await getAction(client, waitForTransactionReceipt, "waitForTransactionReceipt")({ hash: testHook.hash });
     }
 
-    const mailboxImpl = await getOrDeployMailboxImpl(clients);
+    const mailboxImpl = await getOrDeployMailboxImpl(client);
     if (mailboxImpl.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: mailboxImpl.hash });
+        await getAction(client, waitForTransactionReceipt, "waitForTransactionReceipt")({ hash: mailboxImpl.hash });
     }
 
     return { deterministicDeployer, create2Factory, testIsm, testHook, mailboxImpl };
 }
 
-export async function setupTestMailboxContractsWithProxy(clients: Clients) {
-    const { publicClient } = clients;
-
-    const deterministicDeployer = await getOrDeployDeterministicDeployer(clients);
+export async function setupTestMailboxContractsWithProxy(client: Client<Transport, Chain, Account>) {
+    const deterministicDeployer = await getOrDeployDeterministicDeployer(client);
     if (deterministicDeployer.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: deterministicDeployer.hash });
+        await getAction(
+            client,
+            waitForTransactionReceipt,
+            "waitForTransactionReceipt",
+        )({ hash: deterministicDeployer.hash });
     }
 
-    const create2Factory = await getOrDeployCreate2Factory(clients);
+    const create2Factory = await getOrDeployCreate2Factory(client);
     if (create2Factory.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: create2Factory.hash });
+        await getAction(client, waitForTransactionReceipt, "waitForTransactionReceipt")({ hash: create2Factory.hash });
     }
 
-    const testIsm = await getOrDeployTestIsm(clients);
+    const testIsm = await getOrDeployTestIsm(client);
     if (testIsm.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: testIsm.hash });
+        await getAction(client, waitForTransactionReceipt, "waitForTransactionReceipt")({ hash: testIsm.hash });
     }
 
-    const testHook = await getOrDeployTestHook(clients);
+    const testHook = await getOrDeployTestHook(client);
     if (testHook.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: testHook.hash });
+        await getAction(client, waitForTransactionReceipt, "waitForTransactionReceipt")({ hash: testHook.hash });
     }
 
-    const mailboxImpl = await getOrDeployMailboxImpl(clients);
+    const mailboxImpl = await getOrDeployMailboxImpl(client);
     if (mailboxImpl.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: mailboxImpl.hash });
+        await getAction(client, waitForTransactionReceipt, "waitForTransactionReceipt")({ hash: mailboxImpl.hash });
     }
 
-    const mailbox = await getOrDeployMailboxProxy({
-        ...clients,
+    const mailbox = await getOrDeployMailboxProxy(client, {
         mailboxImplAddress: mailboxImpl.address,
         ismAddress: testIsm.address,
         defaultHookAddress: testHook.address,
         requiredHookAddress: testHook.address,
     });
     if (mailbox.hash) {
-        await publicClient.waitForTransactionReceipt({ hash: mailbox.hash });
+        await getAction(client, waitForTransactionReceipt, "waitForTransactionReceipt")({ hash: mailbox.hash });
     }
 
     return { deterministicDeployer, create2Factory, testIsm, testHook, mailboxImpl, mailbox };
 }
 
-export async function getOrDeployTestRecipient({
-    walletClient,
-    publicClient,
-    salt = zeroHash,
-}: {
-    walletClient: WalletClient<Transport, Chain, Account>;
-    publicClient: PublicClient<Transport, Chain>;
-    salt?: Hex;
-}): Promise<{ hash?: Hex; address: Address }> {
-    return getOrDeployDeterministicContract({ publicClient, walletClient }, { salt, bytecode: TestRecipient.bytecode });
+export async function getOrDeployTestRecipient(
+    client: Client<Transport, Chain, Account>,
+    parameters?: {
+        salt?: Hex;
+    },
+): Promise<{ hash?: Hex; address: Address }> {
+    const { salt = zeroHash } = parameters ?? {};
+    return getOrDeployDeterministicContract(client, { salt, bytecode: TestRecipient.bytecode });
 }

--- a/packages/contracts-hyperlane/src/token/dustTokenRecipients.test.ts
+++ b/packages/contracts-hyperlane/src/token/dustTokenRecipients.test.ts
@@ -47,19 +47,16 @@ describe("dustTokenRecipients.test.ts", function () {
         });
 
         //Deploy DeterministicDeployer
-        const { hash: hashDeployer } = await getOrDeployDeterministicDeployer({ publicClient, walletClient });
+        const { hash: hashDeployer } = await getOrDeployDeterministicDeployer(walletClient);
         if (hashDeployer) {
             await publicClient.waitForTransactionReceipt({ hash: hashDeployer });
         }
 
         //Deploy Mock Token Router
-        const tokenRouter = await getOrDeployDeterministicContract(
-            { publicClient, walletClient },
-            {
-                salt: zeroHash,
-                bytecode: MockTokenRouterEventsBytecode,
-            },
-        );
+        const tokenRouter = await getOrDeployDeterministicContract(walletClient, {
+            salt: zeroHash,
+            bytecode: MockTokenRouterEventsBytecode,
+        });
         tokenRouterAddress = tokenRouter.address;
         if (tokenRouter.hash) {
             await publicClient.waitForTransactionReceipt({ hash: tokenRouter.hash });

--- a/packages/contracts-hyperlane/src/token/getOrDeployHypERC20CollateralImpl.ts
+++ b/packages/contracts-hyperlane/src/token/getOrDeployHypERC20CollateralImpl.ts
@@ -1,30 +1,23 @@
 import { getOrDeployDeterministicContract } from "@owlprotocol/viem-utils";
-import { Account, Address, Chain, encodeDeployData, Hex, PublicClient, Transport, WalletClient, zeroHash } from "viem";
+import { Account, Address, Chain, Client, encodeDeployData, Hex, Transport, zeroHash } from "viem";
 import { HypERC20Collateral } from "../artifacts/HypERC20Collateral.js";
 
-export async function getOrDeployHypERC20CollateralImpl({
-    walletClient,
-    publicClient,
-    erc20Address,
-    mailboxAddress,
-    salt = zeroHash,
-}: {
-    walletClient: WalletClient<Transport, Chain, Account>;
-    publicClient: PublicClient<Transport, Chain>;
-    erc20Address: Address;
-    mailboxAddress: Address;
-    decimals?: number;
-    salt?: Hex;
-}) {
-    return getOrDeployDeterministicContract(
-        { publicClient, walletClient },
-        {
-            salt,
-            bytecode: encodeDeployData({
-                abi: HypERC20Collateral.abi,
-                bytecode: HypERC20Collateral.bytecode,
-                args: [erc20Address, mailboxAddress],
-            }),
-        },
-    );
+export async function getOrDeployHypERC20CollateralImpl(
+    client: Client<Transport, Chain, Account>,
+    parameters: {
+        erc20Address: Address;
+        mailboxAddress: Address;
+        decimals?: number;
+        salt?: Hex;
+    },
+) {
+    const { erc20Address, mailboxAddress, salt = zeroHash } = parameters;
+    return getOrDeployDeterministicContract(client, {
+        salt,
+        bytecode: encodeDeployData({
+            abi: HypERC20Collateral.abi,
+            bytecode: HypERC20Collateral.bytecode,
+            args: [erc20Address, mailboxAddress],
+        }),
+    });
 }

--- a/packages/contracts-hyperlane/src/token/getOrDeployHypERC20CollateralProxy.ts
+++ b/packages/contracts-hyperlane/src/token/getOrDeployHypERC20CollateralProxy.ts
@@ -1,36 +1,25 @@
 import { getCloneDeterministicBytecode, getOrDeployContracts } from "@owlprotocol/contracts-create2factory";
-import {
-    Account,
-    Address,
-    Chain,
-    encodeFunctionData,
-    Hex,
-    PublicClient,
-    Transport,
-    WalletClient,
-    zeroAddress,
-    zeroHash,
-} from "viem";
+import { Account, Address, Chain, Client, encodeFunctionData, Hex, Transport, zeroAddress, zeroHash } from "viem";
 import { initialize as initializeAbi } from "../artifacts/HypERC20Collateral.js";
 
-export async function getOrDeployHypERC20CollateralProxy({
-    walletClient,
-    publicClient,
-    hypERC20CollateralImplAddress,
-    hookAddress = zeroAddress,
-    ismAddress = zeroAddress,
-    owner,
-    salt = zeroHash,
-}: {
-    walletClient: WalletClient<Transport, Chain, Account>;
-    publicClient: PublicClient<Transport, Chain>;
-    hypERC20CollateralImplAddress: Address;
-    hookAddress?: Address;
-    ismAddress?: Address;
-    owner: Address;
-    salt?: Hex;
-}) {
-    const deployERC20Collateral = await getOrDeployContracts({ publicClient, walletClient }, zeroAddress, [
+export async function getOrDeployHypERC20CollateralProxy(
+    client: Client<Transport, Chain, Account>,
+    parameters: {
+        hypERC20CollateralImplAddress: Address;
+        hookAddress?: Address;
+        ismAddress?: Address;
+        owner: Address;
+        salt?: Hex;
+    },
+) {
+    const {
+        hypERC20CollateralImplAddress,
+        hookAddress = zeroAddress,
+        ismAddress = zeroAddress,
+        owner,
+        salt = zeroHash,
+    } = parameters;
+    const deployERC20Collateral = await getOrDeployContracts(client, zeroAddress, [
         {
             bytecode: getCloneDeterministicBytecode(hypERC20CollateralImplAddress),
             initData: encodeFunctionData({

--- a/packages/contracts-hyperlane/src/token/getOrDeployHypERC20Impl.ts
+++ b/packages/contracts-hyperlane/src/token/getOrDeployHypERC20Impl.ts
@@ -1,29 +1,22 @@
 import { getOrDeployDeterministicContract } from "@owlprotocol/viem-utils";
-import { Account, Address, Chain, encodeDeployData, Hex, PublicClient, Transport, WalletClient, zeroHash } from "viem";
+import { Account, Address, Chain, Client, encodeDeployData, Hex, Transport, zeroHash } from "viem";
 import { HypERC20 } from "../artifacts/HypERC20.js";
 
-export async function getOrDeployHypERC20Impl({
-    walletClient,
-    publicClient,
-    mailboxAddress,
-    decimals = 18,
-    salt = zeroHash,
-}: {
-    walletClient: WalletClient<Transport, Chain, Account>;
-    publicClient: PublicClient<Transport, Chain>;
-    mailboxAddress: Address;
-    decimals?: number;
-    salt?: Hex;
-}) {
-    return getOrDeployDeterministicContract(
-        { publicClient, walletClient },
-        {
-            salt,
-            bytecode: encodeDeployData({
-                abi: HypERC20.abi,
-                bytecode: HypERC20.bytecode,
-                args: [decimals, mailboxAddress],
-            }),
-        },
-    );
+export async function getOrDeployHypERC20Impl(
+    client: Client<Transport, Chain, Account>,
+    parameters: {
+        mailboxAddress: Address;
+        decimals?: number;
+        salt?: Hex;
+    },
+) {
+    const { mailboxAddress, decimals = 18, salt = zeroHash } = parameters;
+    return getOrDeployDeterministicContract(client, {
+        salt,
+        bytecode: encodeDeployData({
+            abi: HypERC20.abi,
+            bytecode: HypERC20.bytecode,
+            args: [decimals, mailboxAddress],
+        }),
+    });
 }

--- a/packages/contracts-hyperlane/src/token/getOrDeployHypERC20Proxy.ts
+++ b/packages/contracts-hyperlane/src/token/getOrDeployHypERC20Proxy.ts
@@ -1,42 +1,31 @@
 import { getCloneDeterministicBytecode, getOrDeployContracts } from "@owlprotocol/contracts-create2factory";
-import {
-    Account,
-    Address,
-    Chain,
-    encodeFunctionData,
-    Hex,
-    PublicClient,
-    Transport,
-    WalletClient,
-    zeroAddress,
-    zeroHash,
-} from "viem";
+import { Account, Address, Chain, Client, encodeFunctionData, Hex, Transport, zeroAddress, zeroHash } from "viem";
 import { initialize as initializeAbi } from "../artifacts/HypERC20.js";
 
-export async function getOrDeployHypERC20Proxy({
-    walletClient,
-    publicClient,
-    hypERC20ImplAddress,
-    totalSupply,
-    name,
-    symbol,
-    hookAddress = zeroAddress,
-    ismAddress = zeroAddress,
-    owner,
-    salt = zeroHash,
-}: {
-    walletClient: WalletClient<Transport, Chain, Account>;
-    publicClient: PublicClient<Transport, Chain>;
-    hypERC20ImplAddress: Address;
-    totalSupply: bigint;
-    name: string;
-    symbol: string;
-    hookAddress?: Address;
-    ismAddress?: Address;
-    owner: Address;
-    salt?: Hex;
-}) {
-    const deployERC20 = await getOrDeployContracts({ publicClient, walletClient }, zeroAddress, [
+export async function getOrDeployHypERC20Proxy(
+    client: Client<Transport, Chain, Account>,
+    parameters: {
+        hypERC20ImplAddress: Address;
+        totalSupply: bigint;
+        name: string;
+        symbol: string;
+        hookAddress?: Address;
+        ismAddress?: Address;
+        owner: Address;
+        salt?: Hex;
+    },
+) {
+    const {
+        hypERC20ImplAddress,
+        totalSupply,
+        name,
+        symbol,
+        hookAddress = zeroAddress,
+        ismAddress = zeroAddress,
+        owner,
+        salt = zeroHash,
+    } = parameters;
+    const deployERC20 = await getOrDeployContracts(client, zeroAddress, [
         {
             bytecode: getCloneDeterministicBytecode(hypERC20ImplAddress),
             initData: encodeFunctionData({

--- a/packages/viem-utils/src/DeterministicDeployer/deployDeterministicDeployer.ts
+++ b/packages/viem-utils/src/DeterministicDeployer/deployDeterministicDeployer.ts
@@ -1,20 +1,20 @@
-import { Address, Hash, formatEther } from "viem";
+import { Account, Address, Chain, Client, Hash, Transport, formatEther } from "viem";
+import { getAction } from "viem/utils";
+import { getBalance, getCode, sendRawTransaction, sendTransaction, waitForTransactionReceipt } from "viem/actions";
 import { DETERMINISTIC_DEPLOYER_ADDRESS, deployEthCost, deploySignerAddress, deployTransaction } from "./constants.js";
-import { Clients } from "../clients.js";
 
 /**
  * Get or deploy DeterministicDeployer
- * @param clients publicClient, walletClient to fund deployer if needed
+ * @param client Client with chain & account to fund deployer if needed
  * @returns
  */
-export async function getOrDeployDeterministicDeployer(clients: Clients): Promise<{
+export async function getOrDeployDeterministicDeployer(client: Client<Transport, Chain, Account>): Promise<{
     address: Address;
     hash: Hash | undefined;
     existed: boolean;
 }> {
-    const { publicClient, walletClient } = clients;
     //Check if Create2Factory exists
-    const existingByteCode = await publicClient.getBytecode({ address: DETERMINISTIC_DEPLOYER_ADDRESS });
+    const existingByteCode = await getAction(client, getCode, "getCode")({ address: DETERMINISTIC_DEPLOYER_ADDRESS });
     if (existingByteCode != undefined) {
         return {
             address: DETERMINISTIC_DEPLOYER_ADDRESS,
@@ -24,22 +24,32 @@ export async function getOrDeployDeterministicDeployer(clients: Clients): Promis
     }
 
     //Check balance of signer
-    const balance = await publicClient.getBalance({ address: deploySignerAddress });
+    const balance = await getAction(client, getBalance, "getBalance")({ address: deploySignerAddress });
     if (balance < deployEthCost) {
         const deficit = deployEthCost - balance;
         console.debug(
             `DeterministicDeployer signer (${deploySignerAddress}) has deficit of ${formatEther(deficit)} ETH`,
         );
         console.debug(`Funding deployer ${deploySignerAddress}...`);
-        const hash = await walletClient.sendTransaction({
+        const hash = await getAction(
+            client,
+            sendTransaction,
+            "sendTransaction",
+        )({
             to: deploySignerAddress,
             value: deficit,
+            account: client.account,
+            chain: client.chain,
         });
-        await publicClient.waitForTransactionReceipt({ hash });
+        await getAction(client, waitForTransactionReceipt, "waitForTransactionReceipt")({ hash });
     }
 
     //Send raw pre-signed transaction
-    const hash = await publicClient.sendRawTransaction({
+    const hash = await getAction(
+        client,
+        sendRawTransaction,
+        "sendRawTransaction",
+    )({
         serializedTransaction: deployTransaction,
     });
 

--- a/packages/viem-utils/src/DeterministicDeployer/index.test.ts
+++ b/packages/viem-utils/src/DeterministicDeployer/index.test.ts
@@ -40,10 +40,7 @@ describe.skip("DeterministicDeployer.test.ts", function () {
 
     test("getOrDeployDeterministicContract", async () => {
         //Deploy DeterministicDeployer
-        const resultDeployDeterministicDeployer = await getOrDeployDeterministicDeployer({
-            publicClient,
-            walletClient,
-        });
+        const resultDeployDeterministicDeployer = await getOrDeployDeterministicDeployer(walletClient);
         expect(resultDeployDeterministicDeployer.address).toBe(DETERMINISTIC_DEPLOYER_ADDRESS);
 
         //Wait for receipt
@@ -55,7 +52,7 @@ describe.skip("DeterministicDeployer.test.ts", function () {
         }
 
         //Get existing DeterministicDeployer
-        const resultGetDeterministicDeployer = await getOrDeployDeterministicDeployer({ publicClient, walletClient });
+        const resultGetDeterministicDeployer = await getOrDeployDeterministicDeployer(walletClient);
         expect(resultGetDeterministicDeployer.existed).toBe(true);
         expect(resultGetDeterministicDeployer.hash).toBeUndefined();
         expect(resultGetDeterministicDeployer.address).toBe(DETERMINISTIC_DEPLOYER_ADDRESS);
@@ -67,10 +64,7 @@ describe.skip("DeterministicDeployer.test.ts", function () {
         };
         const address = getDeployDeterministicAddress(deployParams);
 
-        const resultDeployMyContract = await getOrDeployDeterministicContract(
-            { publicClient, walletClient },
-            deployParams,
-        );
+        const resultDeployMyContract = await getOrDeployDeterministicContract(walletClient, deployParams);
         expect(resultDeployMyContract.address).toBe(address);
 
         //Wait for receipt
@@ -81,10 +75,7 @@ describe.skip("DeterministicDeployer.test.ts", function () {
         }
 
         //Get existing MyContract
-        const resultGetMyContract = await getOrDeployDeterministicContract(
-            { publicClient, walletClient },
-            deployParams,
-        );
+        const resultGetMyContract = await getOrDeployDeterministicContract(walletClient, deployParams);
         expect(resultGetMyContract.existed).toBe(true);
         expect(resultGetMyContract.hash).toBeUndefined();
         expect(resultGetMyContract.address).toBe(address);

--- a/packages/viem-utils/src/clients.ts
+++ b/packages/viem-utils/src/clients.ts
@@ -1,6 +1,0 @@
-import { Account, Chain, PublicClient, Transport, WalletClient } from "viem";
-
-export type Clients = {
-    publicClient: PublicClient<Transport, Chain>;
-    walletClient: WalletClient<Transport, Chain, Account>;
-};

--- a/packages/viem-utils/src/index.ts
+++ b/packages/viem-utils/src/index.ts
@@ -1,6 +1,5 @@
 export * from "./DeterministicDeployer/index.js";
 export * from "./accounts.js";
-export * from "./clients.js";
 export * from "./logDeployment.js";
 export * from "./topupAddress.js";
 export * from "./topupAddressL2.js";


### PR DESCRIPTION
Refactor deployer utils use single client with account without need for decorators.
This makes things more modular and aligns them with the format of regular viem actions.