### PR TITLE
Dev 1246 hyperlane chains deploy

### DIFF
--- a/packages/chains-deploy/package.json
+++ b/packages/chains-deploy/package.json
@@ -61,6 +61,7 @@
     "@owlprotocol/contracts-account-abstraction": "workspace:*",
     "@owlprotocol/contracts-create2factory": "workspace:*",
     "@owlprotocol/contracts-diamond": "workspace:*",
+    "@owlprotocol/contracts-hyperlane": "workspace:*",
     "@owlprotocol/core-firebase": "workspace:*",
     "@owlprotocol/envvars": "workspace:*",
     "@owlprotocol/viem-utils": "workspace:*",

--- a/packages/chains-deploy/src/setupChain.test.ts
+++ b/packages/chains-deploy/src/setupChain.test.ts
@@ -1,33 +1,78 @@
-import { expect } from "vitest";
+import { beforeAll, expect } from "vitest";
 
 import {
     DETERMINISTIC_DEPLOYER_ADDRESS,
+    getLocalAccount,
+    getOrDeployDeterministicContract,
+    getOrDeployDeterministicDeployer,
     getPaymasterSignerAccount,
     getRelayerAccount,
     getUtilityAccount,
 } from "@owlprotocol/viem-utils";
-import { createClient, createPublicClient, http, nonceManager } from "viem";
+import {
+    Address,
+    createClient,
+    createPublicClient,
+    createWalletClient,
+    encodeDeployData,
+    http,
+    nonceManager,
+    zeroHash,
+} from "viem";
 import { localhost } from "viem/chains";
 import { describe, test } from "vitest";
+import { Mailbox } from "@owlprotocol/contracts-hyperlane/artifacts/Mailbox";
 import { setupChain } from "./setupChain.js";
 import { port } from "./test/constants.js";
 
 describe("setupChain.test.ts", function () {
-    test("setupChain", async () => {
-        const chain = {
-            ...localhost,
-            rpcUrls: {
-                default: {
-                    http: [`http://127.0.0.1:${port}`],
-                },
+    const chain = {
+        ...localhost,
+        rpcUrls: {
+            default: {
+                http: [`http://127.0.0.1:${port}`],
             },
-        };
-        const transport = http(chain.rpcUrls.default.http[0]);
+        },
+    };
+    const transport = http(chain.rpcUrls.default.http[0]);
 
-        const publicClient = createPublicClient({
-            transport,
+    const publicClient = createPublicClient({
+        transport,
+        chain,
+    });
+
+    let mailboxAddress: Address;
+
+    beforeAll(async () => {
+        const walletClient = createWalletClient({
+            account: getLocalAccount(0, { nonceManager }),
             chain,
+            transport,
         });
+        // Deploy DeterministicDeployer (for dummy Mailbox)
+        const deployer = await getOrDeployDeterministicDeployer(walletClient);
+        if (deployer.hash) {
+            await publicClient.waitForTransactionReceipt({ hash: deployer.hash });
+        }
+
+        // Deploy dummy Mailbox contract deployments dont't fail
+        // Warning: This mailbox is NOT initialized and cannot be used directly
+        const mailbox = await getOrDeployDeterministicContract(walletClient, {
+            salt: zeroHash,
+            bytecode: encodeDeployData({
+                abi: Mailbox.abi,
+                bytecode: Mailbox.bytecode,
+                args: [walletClient.chain.id],
+            }),
+        });
+        if (mailbox.hash) {
+            await publicClient.waitForTransactionReceipt({ hash: mailbox.hash });
+        }
+
+        mailboxAddress = mailbox.address;
+    });
+
+    test("setupChain", async () => {
         //Load viem utility account
         const utilityAccount = getUtilityAccount({ nonceManager });
         // Load viem bundler account
@@ -45,6 +90,7 @@ describe("setupChain.test.ts", function () {
         const result = await setupChain(utilityClient, {
             bundlerAddress: bundlerAccount.address,
             verifyingSignerAddress: paymasterSignerAccount.address,
+            mailboxAddress,
         });
         expect(result).toBeDefined();
 
@@ -75,6 +121,11 @@ describe("setupChain.test.ts", function () {
 
         // Create2Factory
         expect(await publicClient.getCode({ address: result.create2Factory.address })).toBeDefined();
+
+        // Hyperlane
+        expect(await publicClient.getCode({ address: result.hypErc20!.address })).toBeDefined();
+        expect(await publicClient.getCode({ address: result.hypErc20Fast!.address })).toBeDefined();
+        expect(await publicClient.getCode({ address: result.hypNative!.address })).toBeDefined();
 
         // Verifying Payaster
         expect(await publicClient.getCode({ address: result.verifyingPaymaster.address })).toBeDefined();

--- a/packages/chains-deploy/src/setupChain.ts
+++ b/packages/chains-deploy/src/setupChain.ts
@@ -1,10 +1,10 @@
-import { Address, Transport, Chain, WalletClient, Account, Client } from "viem";
+import { Address, Transport, Chain, WalletClient, Account, Client, Prettify } from "viem";
 import { topupAddress } from "@owlprotocol/viem-utils";
 import { topupPaymaster } from "@owlprotocol/contracts-account-abstraction";
 import { getAction } from "viem/utils";
 import { getGasPrice, waitForTransactionReceipt } from "viem/actions";
 import { topupUtilityAccount } from "./topupUtilityAccount.js";
-import { setupChainContracts } from "./setupChainContracts.js";
+import { SetupChainContractParameters, setupChainContracts } from "./setupChainContracts.js";
 
 /**
  * Setup network end to end.
@@ -14,30 +14,30 @@ import { setupChainContracts } from "./setupChainContracts.js";
  * 3. Topup Bundler
  * 4. Topup Paymaster
  */
-export type SetupChainParams = {
-    /** Bundler relayer */
-    bundlerAddress: Address;
-    /** Paymaster signer */
-    verifyingSignerAddress: Address;
-    /** Bundler gas budget */
-    bundlerGasBudget?: bigint;
-    /** Bundler target balance */
-    bundlerTargetBalance?: bigint;
-    /** Bundler min balance */
-    bundlerMinBalance?: bigint;
-    /** Paymaster gas budget */
-    paymasterGasBudget?: bigint;
-    /** Paymaster target balance */
-    paymasterTargetBalance?: bigint;
-    /** Paymaster min balance */
-    paymasterMinBalance?: bigint;
-    /** Target utility balance for topup */
-    utilityTargetBalance?: bigint;
-    /** Min utility balance to trigger topup */
-    utilityMinBalance?: bigint;
-    /** L1 Client for topup */
-    clientL1?: WalletClient<Transport, Chain, Account>;
-};
+export type SetupChainParams = Prettify<
+    {
+        /** Bundler relayer */
+        bundlerAddress: Address;
+        /** Bundler gas budget */
+        bundlerGasBudget?: bigint;
+        /** Bundler target balance */
+        bundlerTargetBalance?: bigint;
+        /** Bundler min balance */
+        bundlerMinBalance?: bigint;
+        /** Paymaster gas budget */
+        paymasterGasBudget?: bigint;
+        /** Paymaster target balance */
+        paymasterTargetBalance?: bigint;
+        /** Paymaster min balance */
+        paymasterMinBalance?: bigint;
+        /** Target utility balance for topup */
+        utilityTargetBalance?: bigint;
+        /** Min utility balance to trigger topup */
+        utilityMinBalance?: bigint;
+        /** L1 Client for topup */
+        clientL1?: WalletClient<Transport, Chain, Account>;
+    } & SetupChainContractParameters
+>;
 
 /**
  * Topup chain utility account
@@ -75,8 +75,8 @@ export async function setupChain(client: Client<Transport, Chain, Account>, para
     });
 
     //2. Contracts
-    const { verifyingSignerAddress } = params;
-    const contracts = await setupChainContracts(client, { verifyingSignerAddress });
+    const { verifyingSignerAddress, mailboxAddress } = params;
+    const contracts = await setupChainContracts(client, { verifyingSignerAddress, mailboxAddress });
 
     //3. Bundler Topup
     const { bundlerAddress } = params;

--- a/packages/chains-deploy/src/setupChainContracts.test.ts
+++ b/packages/chains-deploy/src/setupChainContracts.test.ts
@@ -1,9 +1,17 @@
-import { expect } from "vitest";
+import { beforeAll, expect } from "vitest";
 
-import { DETERMINISTIC_DEPLOYER_ADDRESS, getLocalAccount, getPaymasterSignerAccount } from "@owlprotocol/viem-utils";
-import { createPublicClient, createWalletClient, http, nonceManager } from "viem";
+import {
+    DETERMINISTIC_DEPLOYER_ADDRESS,
+    getLocalAccount,
+    getOrDeployDeterministicContract,
+    getOrDeployDeterministicDeployer,
+    getPaymasterSignerAccount,
+} from "@owlprotocol/viem-utils";
+import { Address, createPublicClient, createWalletClient, encodeDeployData, http, nonceManager, zeroHash } from "viem";
 import { localhost } from "viem/chains";
 import { describe, test } from "vitest";
+
+import { Mailbox } from "@owlprotocol/contracts-hyperlane/artifacts/Mailbox";
 import { port } from "./test/constants.js";
 import { prepareChainContracts, setupChainContracts } from "./setupChainContracts.js";
 
@@ -43,6 +51,37 @@ describe("setupChainContracts.test.ts", function () {
     });
     */
 
+    let mailboxAddress: Address;
+
+    beforeAll(async () => {
+        const walletClient = createWalletClient({
+            account: getLocalAccount(0, { nonceManager }),
+            chain,
+            transport,
+        });
+        // Deploy DeterministicDeployer (for dummy Mailbox)
+        const deployer = await getOrDeployDeterministicDeployer(walletClient);
+        if (deployer.hash) {
+            await publicClient.waitForTransactionReceipt({ hash: deployer.hash });
+        }
+
+        // Deploy dummy Mailbox contract deployments dont't fail
+        // Warning: This mailbox is NOT initialized and cannot be used directly
+        const mailbox = await getOrDeployDeterministicContract(walletClient, {
+            salt: zeroHash,
+            bytecode: encodeDeployData({
+                abi: Mailbox.abi,
+                bytecode: Mailbox.bytecode,
+                args: [walletClient.chain.id],
+            }),
+        });
+        if (mailbox.hash) {
+            await publicClient.waitForTransactionReceipt({ hash: mailbox.hash });
+        }
+
+        mailboxAddress = mailbox.address;
+    });
+
     test("prepareChainContracts", async () => {
         const contracts = await prepareChainContracts(walletClient);
         const contractsGas = contracts.requests.reduce((acc, request) => acc + (request.gas ?? 0n), 0n);
@@ -54,6 +93,7 @@ describe("setupChainContracts.test.ts", function () {
         const paymasterSignerAccount = getPaymasterSignerAccount();
         const result = await setupChainContracts(walletClient, {
             verifyingSignerAddress: paymasterSignerAccount.address,
+            mailboxAddress,
         });
         expect(result).toBeDefined();
 
@@ -84,6 +124,11 @@ describe("setupChainContracts.test.ts", function () {
 
         // Create2Factory
         expect(await publicClient.getCode({ address: result.create2Factory.address })).toBeDefined();
+
+        // Hyperlane
+        expect(await publicClient.getCode({ address: result.hypErc20!.address })).toBeDefined();
+        expect(await publicClient.getCode({ address: result.hypErc20Fast!.address })).toBeDefined();
+        expect(await publicClient.getCode({ address: result.hypNative!.address })).toBeDefined();
 
         // Verifying Payaster
         expect(await publicClient.getCode({ address: result.verifyingPaymaster.address })).toBeDefined();

--- a/packages/chains-deploy/src/setupChainContracts.ts
+++ b/packages/chains-deploy/src/setupChainContracts.ts
@@ -2,7 +2,8 @@ import { Account, Address, Chain, Client, formatEther, TransactionRequest, Trans
 import { getAction } from "viem/utils";
 import { getBalance, sendTransaction, waitForTransactionReceipt } from "viem/actions";
 
-import { getOrDeployDeterministicDeployer } from "@owlprotocol/viem-utils";
+import { getOrDeployDeterministicDeployer, GetOrPrepareDeterministicContractReturnType } from "@owlprotocol/viem-utils";
+
 import { prepareERC4337Contracts, setupVerifyingPaymaster } from "@owlprotocol/contracts-account-abstraction";
 import { prepareDiamondFacets, prepareERC721Facets, prepareCoreContractFacets } from "@owlprotocol/contracts-diamond";
 import { prepareHyperlaneContracts } from "@owlprotocol/contracts-hyperlane";
@@ -38,6 +39,9 @@ export async function prepareChainContracts(
         ...erc721Facets,
         create2Factory,
         requests,
+        hypErc20: undefined as undefined | GetOrPrepareDeterministicContractReturnType,
+        hypErc20Fast: undefined as undefined | GetOrPrepareDeterministicContractReturnType,
+        hypNative: undefined as undefined | GetOrPrepareDeterministicContractReturnType,
     };
 
     //TODO: Refactor for more optional deployments, for now this is enough for type inference
@@ -45,13 +49,20 @@ export async function prepareChainContracts(
         //Deploy Hyperlane implementations if mailbox defined
         const hyperlaneImplementations = await prepareHyperlaneContracts(client, { mailboxAddress });
         if (hyperlaneImplementations.requests) requests.push(...hyperlaneImplementations.requests);
-        return {
-            ...result,
-            ...hyperlaneImplementations,
-        };
-    } else {
-        return result;
+
+        result.hypErc20 = hyperlaneImplementations.hypErc20;
+        result.hypErc20Fast = hyperlaneImplementations.hypErc20Fast;
+        result.hypNative = hyperlaneImplementations.hypNative;
     }
+
+    return result;
+}
+
+export interface SetupChainContractParameters {
+    /** Paymaster signer */
+    verifyingSignerAddress: Address;
+    /** Hyperlane Mailbox */
+    mailboxAddress?: Address;
 }
 
 /**
@@ -71,10 +82,7 @@ export async function prepareChainContracts(
  */
 export async function setupChainContracts(
     client: Client<Transport, Chain, Account>,
-    parameters: {
-        verifyingSignerAddress: Address;
-        mailboxAddress?: Address;
-    },
+    parameters: SetupChainContractParameters,
 ) {
     if (!client.account.nonceManager) {
         throw new Error("client.account.nonceManager undefined");
@@ -88,7 +96,7 @@ export async function setupChainContracts(
     }
 
     //1. Deploy contracts
-    const contracts = await prepareChainContracts(client);
+    const contracts = await prepareChainContracts(client, parameters);
 
     // Check balance
     const contractsFee = contracts.requests.reduce(

--- a/packages/chains-deploy/src/setupChainContracts.ts
+++ b/packages/chains-deploy/src/setupChainContracts.ts
@@ -1,12 +1,18 @@
 import { Account, Address, Chain, Client, formatEther, TransactionRequest, Transport } from "viem";
-import { prepareERC4337Contracts, setupVerifyingPaymaster } from "@owlprotocol/contracts-account-abstraction";
-import { getOrPrepareCreate2Factory } from "@owlprotocol/contracts-create2factory";
-import { prepareDiamondFacets, prepareERC721Facets, prepareCoreContractFacets } from "@owlprotocol/contracts-diamond";
-import { getOrDeployDeterministicDeployer } from "@owlprotocol/viem-utils";
 import { getAction } from "viem/utils";
 import { getBalance, sendTransaction, waitForTransactionReceipt } from "viem/actions";
 
-export async function prepareChainContracts(client: Client<Transport, Chain, Account>) {
+import { getOrDeployDeterministicDeployer } from "@owlprotocol/viem-utils";
+import { prepareERC4337Contracts, setupVerifyingPaymaster } from "@owlprotocol/contracts-account-abstraction";
+import { prepareDiamondFacets, prepareERC721Facets, prepareCoreContractFacets } from "@owlprotocol/contracts-diamond";
+import { prepareHyperlaneContracts } from "@owlprotocol/contracts-hyperlane";
+import { getOrPrepareCreate2Factory } from "@owlprotocol/contracts-create2factory";
+
+export async function prepareChainContracts(
+    client: Client<Transport, Chain, Account>,
+    parameters?: { mailboxAddress?: Address },
+) {
+    const { mailboxAddress } = parameters ?? {};
     const requests: TransactionRequest[] = [];
 
     const [erc4337Contracts, diamondFacets, coreFacets, erc721Facets, create2Factory] = await Promise.all([
@@ -25,7 +31,7 @@ export async function prepareChainContracts(client: Client<Transport, Chain, Acc
     );
     if (create2Factory.request) requests.push(create2Factory.request);
 
-    return {
+    const result = {
         ...erc4337Contracts,
         ...diamondFacets,
         ...coreFacets,
@@ -33,6 +39,19 @@ export async function prepareChainContracts(client: Client<Transport, Chain, Acc
         create2Factory,
         requests,
     };
+
+    //TODO: Refactor for more optional deployments, for now this is enough for type inference
+    if (mailboxAddress) {
+        //Deploy Hyperlane implementations if mailbox defined
+        const hyperlaneImplementations = await prepareHyperlaneContracts(client, { mailboxAddress });
+        if (hyperlaneImplementations.requests) requests.push(...hyperlaneImplementations.requests);
+        return {
+            ...result,
+            ...hyperlaneImplementations,
+        };
+    } else {
+        return result;
+    }
 }
 
 /**
@@ -43,9 +62,10 @@ export async function prepareChainContracts(client: Client<Transport, Chain, Acc
  *   - Create2Factory (0x62366409c9E4D9c7b255d6A8990320A6e4c29B17)
  *   - EntryPointV07  (0x0000000071727De22E5E9d8BAf0edAc6f37da032)
  *   - SimpleAccountFactory (0x91E60e0613810449d098b0b5Ec8b51A0FE8c8985)
+ *   - Diamond contracts
+ *   - Hyperlane implementations
  * Production / Staging
  *   - VerifyingPaymaster (TBD / 0x2e23ef1375aA642504bED97676A566F5A3E4ae5A)
- *   - Diamond contracts
  * @param client with accoutn and nonceManager
  * @param parameters paymaster signer address
  */
@@ -53,6 +73,7 @@ export async function setupChainContracts(
     client: Client<Transport, Chain, Account>,
     parameters: {
         verifyingSignerAddress: Address;
+        mailboxAddress?: Address;
     },
 ) {
     if (!client.account.nonceManager) {

--- a/packages/chains-deploy/src/setupNetworks.ts
+++ b/packages/chains-deploy/src/setupNetworks.ts
@@ -4,6 +4,8 @@ import { Network, NetworkDataInput, networkPrivateResource, networkResource } fr
 import { localhost, opBedrockL1, opBedrockL2 } from "@owlprotocol/chains";
 import * as chains from "@owlprotocol/chains/chains";
 import { getUtilityAccount, getRelayerAccount, getPaymasterSignerAccount } from "@owlprotocol/viem-utils";
+import { getHyperlaneRegistryChainAddresses, getHyperlaneRegistryMetadata } from "@owlprotocol/contracts-hyperlane";
+
 import { Chain, createPublicClient, createWalletClient, http, nonceManager } from "viem";
 import { setupChain } from "./setupChain.js";
 
@@ -128,6 +130,11 @@ export async function setupNetworksForEnv() {
     //TODO: Chains that don't work
     const skipChainIds: number[] = [chains.linea.chainId, chains.lineaSepolia.chainId, chains.mainnet.chainId];
 
+    //TODO: Enable localhost custom registry override?
+
+    //Fetch full metadata to simply use chainIds instead of Hyperlane chain names
+    const hyperlaneMetadata = await getHyperlaneRegistryMetadata();
+
     for (const network of networksPrivate) {
         const chain = { id: network.chainId, ...network } as Chain;
 
@@ -153,9 +160,25 @@ export async function setupNetworksForEnv() {
 
         console.debug(`🛠️  Deploying ${network.name}`);
 
+        //TODO: get mailbox address
+        //TODO: Is the slug name === hyperlane name??? Add custom override for when these don't match
+        const hyperlaneChain = Object.values(hyperlaneMetadata).find((hyperlaneChain) => {
+            const chainId =
+                typeof hyperlaneChain.chainId === "number" ? hyperlaneChain.chainId : parseInt(hyperlaneChain.chainId);
+            return chainId === chain.id;
+        });
+        const hyperlaneChainName = hyperlaneChain?.name;
+
+        const hyperlaneAddresses = hyperlaneChainName
+            ? await getHyperlaneRegistryChainAddresses(hyperlaneChainName)
+            : null;
+
+        const mailboxAddress = hyperlaneAddresses ? hyperlaneAddresses.mailbox : undefined;
+
         const result = await setupChain(walletClient, {
             bundlerAddress: bundlerAccount.address,
             verifyingSignerAddress: paymasterSignerAccount.address,
+            mailboxAddress,
             clientL1: walletClientL1 as any,
             bundlerTargetBalance: network.targetRelayerBalance as bigint,
             bundlerMinBalance: network.minRelayerBalance as bigint,

--- a/packages/contracts-diamond/src/Diamond.test.ts
+++ b/packages/contracts-diamond/src/Diamond.test.ts
@@ -268,12 +268,13 @@ describe("Diamond.test.ts", function () {
             }),
             functionSelectors: getAbiFunctionSelectors(MyContract.abi),
         };
-        await walletClient.writeContract({
+        const hash = await walletClient.writeContract({
             address: diamondAddress,
             abi: IDiamondCut.abi,
             functionName: "diamondCut",
             args: [[{ ...facetAdd, action: FacetCutAction.Add }], zeroAddress, "0x"],
         });
+        await publicClient.waitForTransactionReceipt({ hash });
 
         //Diamond Loupe
         const facets1 = await publicClient.readContract({

--- a/packages/contracts-hyperlane/src/index.ts
+++ b/packages/contracts-hyperlane/src/index.ts
@@ -8,3 +8,5 @@ export * from "./token/index.js";
 export * from "./artifacts/index.js";
 
 export * from "./prepareHyperlaneContracts.js";
+
+export * from "./registry.js";

--- a/packages/contracts-hyperlane/src/index.ts
+++ b/packages/contracts-hyperlane/src/index.ts
@@ -6,3 +6,5 @@ export * from "./mailbox/index.js";
 
 export * from "./token/index.js";
 export * from "./artifacts/index.js";
+
+export * from "./prepareHyperlaneContracts.js";

--- a/packages/contracts-hyperlane/src/prepareHyperlaneContracts.ts
+++ b/packages/contracts-hyperlane/src/prepareHyperlaneContracts.ts
@@ -1,0 +1,96 @@
+import { getDeployDeterministicAddress, getOrPrepareDeterministicContract } from "@owlprotocol/viem-utils";
+import { Account, Address, Chain, Client, encodeDeployData, TransactionRequest, Transport, zeroHash } from "viem";
+
+import { HypERC20 } from "./artifacts/HypERC20.js";
+import { FastHypERC20 } from "./artifacts/FastHypERC20.js";
+import { HypNative } from "./artifacts/HypNative.js";
+
+/**
+ * Get Hyperlane contract implementation addresses
+ * @warning We only deploy implementations that have only static variables in the constructor (eg. mailbox)
+ * @returns addresses
+ */
+export function getHyperlaneContracts({ mailboxAddress }: { mailboxAddress: Address }) {
+    const [hypErc20, hypErc20Fast, hypNative] = [
+        getDeployDeterministicAddress({
+            salt: zeroHash,
+            bytecode: encodeDeployData({
+                abi: HypERC20.abi,
+                bytecode: HypERC20.bytecode,
+                args: [18, mailboxAddress],
+            }),
+        }),
+        getDeployDeterministicAddress({
+            salt: zeroHash,
+            bytecode: encodeDeployData({
+                abi: FastHypERC20.abi,
+                bytecode: FastHypERC20.bytecode,
+                args: [18, mailboxAddress],
+            }),
+        }),
+        getDeployDeterministicAddress({
+            salt: zeroHash,
+            bytecode: encodeDeployData({
+                abi: HypNative.abi,
+                bytecode: HypNative.bytecode,
+                args: [mailboxAddress],
+            }),
+        }),
+    ];
+
+    return {
+        hypErc20,
+        hypErc20Fast,
+        hypNative,
+    };
+}
+
+/**
+ * Prepare Hyperlane implementation contract deployment transactions. Useful to do gas estimations before sending transaction
+ * @warning We only deploy implementations that have only static variables in the constructor (eg. mailbox)
+ * @param client with account
+ */
+export async function prepareHyperlaneContracts(
+    client: Client<Transport, Chain, Account>,
+    { mailboxAddress }: { mailboxAddress: Address },
+) {
+    const requests: TransactionRequest[] = [];
+
+    //Tokens
+    const [hypErc20, hypErc20Fast, hypNative] = await Promise.all([
+        getOrPrepareDeterministicContract(client, {
+            salt: zeroHash,
+            bytecode: encodeDeployData({
+                abi: HypERC20.abi,
+                bytecode: HypERC20.bytecode,
+                args: [18, mailboxAddress],
+            }),
+        }),
+        getOrPrepareDeterministicContract(client, {
+            salt: zeroHash,
+            bytecode: encodeDeployData({
+                abi: FastHypERC20.abi,
+                bytecode: FastHypERC20.bytecode,
+                args: [18, mailboxAddress],
+            }),
+        }),
+        getOrPrepareDeterministicContract(client, {
+            salt: zeroHash,
+            bytecode: encodeDeployData({
+                abi: HypNative.abi,
+                bytecode: HypNative.bytecode,
+                args: [mailboxAddress],
+            }),
+        }),
+    ]);
+    if (hypErc20.request) requests.push(hypErc20.request);
+    if (hypErc20Fast.request) requests.push(hypErc20Fast.request);
+    if (hypNative.request) requests.push(hypNative.request);
+
+    return {
+        requests,
+        hypErc20,
+        hypErc20Fast,
+        hypNative,
+    };
+}

--- a/packages/contracts-hyperlane/src/registry.ts
+++ b/packages/contracts-hyperlane/src/registry.ts
@@ -1,0 +1,128 @@
+import { GithubRegistry, IRegistry } from "@hyperlane-xyz/registry";
+import { Address } from "viem";
+
+type MaybePromise<T> = T | Promise<T> | PromiseLike<T>;
+
+/** Hyperlane Registry Chain Metadata (sdk type inference seems to break) */
+export interface HyperlaneChainMetadata {
+    chainId: string | number;
+    name: string;
+    logoUri?: string;
+    [key: string]: any;
+}
+
+/** Hyperlane Registry getChainAddresses retrurn type with stricter types */
+export interface HyperlaneChainAddresses {
+    aggregationHook?: Address;
+    domainRoutingIsm?: Address;
+    domainRoutingIsmFactory?: Address;
+    fallbackRoutingHook?: Address;
+    interchainAccountIsm?: Address;
+    interchainAccountRouter?: Address;
+    interchainGasPaymaster?: Address;
+    interchainSecurityModule?: Address;
+    mailbox?: Address;
+    merkleTreeHook?: Address;
+    pausableHook?: Address;
+    pausableIsm?: Address;
+    protocolFee: Address;
+    proxyAdmin?: Address;
+    staticAggregationHookFactory?: Address;
+    staticAggregationIsm?: Address;
+    staticAggregationIsmFactory?: Address;
+    staticMerkleRootMultisigIsmFactory?: Address;
+    staticMerkleRootWeightedMultisigIsmFactory?: Address;
+    staticMessageIdMultisigIsmFactory?: Address;
+    staticMessageIdWeightedMultisigIsmFactory?: Address;
+    storageGasOracle?: Address;
+    testRecipient?: Address;
+    testTokenRecipient?: Address;
+    timelockController?: Address;
+    validatorAnnounce?: Address;
+    [key: string]: Address | undefined;
+}
+
+export interface HyperlaneRegistryData {
+    metadata: Record<string, HyperlaneChainMetadata>;
+    addresses: Record<string, HyperlaneChainAddresses>;
+}
+
+/** Partial IRegistry interface for commond read functionality */
+export interface IRegistryRead {
+    getChains(): MaybePromise<string[]>;
+    getMetadata(): MaybePromise<Record<string, HyperlaneChainMetadata>>;
+    getChainMetadata(chainName: string): MaybePromise<HyperlaneChainMetadata | null>;
+    getAddresses(): MaybePromise<Record<string, Record<string, string>>>;
+    getChainAddresses(chainName: string): MaybePromise<Record<string, string> | null>;
+    getChainLogoUri(chainName: string): Promise<string | null>;
+}
+
+/**
+ * Create Hyperlane Registry with data
+ * @warning Only implements read functionality
+ * @returns IRegistryRead
+ */
+export function creatHyperlaneRegistryWithData(data: HyperlaneRegistryData): IRegistryRead {
+    return {
+        getChains: () => {
+            return Object.keys(data.metadata);
+        },
+        getMetadata: () => {
+            return data.metadata;
+        },
+        getChainMetadata: (chainName: string) => {
+            return data.metadata[chainName];
+        },
+        getChainLogoUri: async (chainName: string) => {
+            return data.metadata[chainName].logoUri ?? null;
+        },
+        getChainAddresses: async (chainName: string) => {
+            return (data.addresses[chainName] as Record<string, string>) ?? null;
+        },
+        getAddresses: () => {
+            return data.addresses as Record<string, Record<string, string>>;
+        },
+    };
+}
+
+/** Default Hyperlane Registyr URL */
+export const REGISTRY_URL = "https://proxy.hyperlane.xyz";
+
+/**
+ * Get Hyperlane Registry
+ * @param url
+ * @returns Hyperlane Registry
+ */
+export function getHyperlaneRegistry(url = REGISTRY_URL) {
+    return new GithubRegistry({
+        proxyUrl: url,
+    });
+}
+
+/** Default Hyperlane Registry */
+export const hyperlaneRegistry = getHyperlaneRegistry();
+
+/**
+ * Get Hyperlane addresses for chain
+ * @param chainName
+ * @param registry
+ * @returns HyperlaneChainAddresses or null
+ */
+export function getHyperlaneRegistryChainAddresses(
+    chainName: string,
+    registry: Pick<IRegistry, "getChainAddresses"> = hyperlaneRegistry,
+): Promise<HyperlaneChainAddresses | null> {
+    return registry.getChainAddresses(chainName) as Promise<HyperlaneChainAddresses | null>;
+}
+
+//TODO: memoize?
+/**
+ * Get Hyperlane metadata
+ * @param registry
+ * @returns
+ */
+export function getHyperlaneRegistryMetadata(
+    registry: Pick<IRegistry, "getMetadata"> = hyperlaneRegistry,
+): Promise<Record<string, HyperlaneChainMetadata>> {
+    return registry.getMetadata();
+}

--- a/packages/viem-utils/src/DeterministicDeployer/getTransaction.ts
+++ b/packages/viem-utils/src/DeterministicDeployer/getTransaction.ts
@@ -38,6 +38,11 @@ export function getDeployDeterministicFunctionData({ salt, bytecode }: { salt: H
     };
 }
 
+export interface GetOrPrepareDeterministicContractReturnType {
+    address: Address;
+    request: TransactionRequest | undefined;
+    existed: boolean;
+}
 /**
  * Get or prepare contract deployment using DeterministicDeployer
  * @param client Client with chain & account
@@ -48,11 +53,7 @@ export function getDeployDeterministicFunctionData({ salt, bytecode }: { salt: H
 export async function getOrPrepareDeterministicContract(
     client: Client<Transport, Chain, Account>,
     { salt, bytecode }: { salt: Hash; bytecode: Hex },
-): Promise<{
-    address: Address;
-    request: TransactionRequest | undefined;
-    existed: boolean;
-}> {
+): Promise<GetOrPrepareDeterministicContractReturnType> {
     //Make sure DeterministicDeployer exists
     if ((await getAction(client, getCode, "getCode")({ address: DETERMINISTIC_DEPLOYER_ADDRESS })) === undefined) {
         throw new Error(
@@ -92,6 +93,11 @@ export async function getOrPrepareDeterministicContract(
     };
 }
 
+export interface GetOrDeployDeterministicContractReturnType {
+    address: Address;
+    hash: Hash | undefined;
+    existed: boolean;
+}
 /**
  * Get or deploy contract using DeterministicDeployer
  * @param client Client with chain & account
@@ -102,11 +108,7 @@ export async function getOrPrepareDeterministicContract(
 export async function getOrDeployDeterministicContract(
     client: Client<Transport, Chain, Account>,
     { salt, bytecode }: { salt: Hash; bytecode: Hex },
-): Promise<{
-    address: Address;
-    hash: Hash | undefined;
-    existed: boolean;
-}> {
+): Promise<GetOrDeployDeterministicContractReturnType> {
     const { address, request, existed } = await getOrPrepareDeterministicContract(client, { salt, bytecode });
 
     let hash: Hash | undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,6 +654,9 @@ importers:
       '@owlprotocol/contracts-diamond':
         specifier: workspace:*
         version: link:../contracts-diamond
+      '@owlprotocol/contracts-hyperlane':
+        specifier: workspace:*
+        version: link:../contracts-hyperlane
       '@owlprotocol/core-firebase':
         specifier: workspace:*
         version: link:../core-firebase


### PR DESCRIPTION
## Overview
Deploy Hyperlane contracts that can use a single implementation. These are contracts that only have the `mailboxAddress` as a parameter.

* HypERC20
* HypERC20Fast
* HypNative: (decimals assumed as 18)

For other contracts, user MUST deploy implementation and then proxy (minimal, ownable etc...)

## Updates
* cotracts-hyperlane: Add main `prepareHyperlaneContracts` to prepare deployment of implementations
* contracts-hyperlane: Additional utils for registry
* chains-deploy: Update deployment script for `setupChainContracts`

## TODO
* Test `setupNetworks` which calls registry to fetch mailbox address of network
EDIT: I tested chains-deploy on staging and the registry api calls work fine. If no mailbox, Hyperlane deployment is just skipped.

